### PR TITLE
Fix .gitattributes

### DIFF
--- a/.gitattrubutes
+++ b/.gitattrubutes
@@ -1,4 +1,4 @@
-app/src/gen/*             linguist-generated=true
-internal/gen/*            linguist-generated=true
-internal/store/queries/*  linguist-generated=true
-ui/src/gen/*  
+app/src/gen/**              linguist-generated=true
+internal/gen/**             linguist-generated=true
+internal/store/queries/**   linguist-generated=true
+ui/src/gen/**               linguist-generated=true


### PR DESCRIPTION
Ensures that all sub-files of `gen/` directories are hidden in PRs