### PR TITLE
store: organizations: add working list, get, update

### DIFF
--- a/internal/store/organizations.go
+++ b/internal/store/organizations.go
@@ -2,15 +2,76 @@ package store
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/google/uuid"
 	"github.com/openauth-dev/openauth/internal/authn"
 	backendv1 "github.com/openauth-dev/openauth/internal/gen/backend/v1"
-	frontendv1 "github.com/openauth-dev/openauth/internal/gen/frontend/v1"
 	openauthv1 "github.com/openauth-dev/openauth/internal/gen/openauth/v1"
 	"github.com/openauth-dev/openauth/internal/store/idformat"
 	"github.com/openauth-dev/openauth/internal/store/queries"
 )
+
+func (s *Store) ListOrganizations(ctx context.Context, req *backendv1.ListOrganizationsRequest) (*backendv1.ListOrganizationsResponse, error) {
+	_, q, _, rollback, err := s.tx(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer rollback()
+
+	var startID uuid.UUID
+	if err := s.pageEncoder.Unmarshal(req.PageToken, &startID); err != nil {
+		return nil, err
+	}
+
+	limit := 10
+	organizationRecords, err := q.ListOrganizationsByProjectId(ctx, queries.ListOrganizationsByProjectIdParams{
+		ProjectID: authn.ProjectID(ctx),
+		Limit:     int32(limit + 1),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("list organizations: %w", err)
+	}
+
+	var organizations []*openauthv1.Organization
+	for _, organization := range organizationRecords {
+		organizations = append(organizations, parseOrganization(organization))
+	}
+
+	var nextPageToken string
+	if len(organizations) == limit+1 {
+		nextPageToken = s.pageEncoder.Marshal(organizations[limit].Id)
+		organizations = organizations[:limit]
+	}
+
+	return &backendv1.ListOrganizationsResponse{
+		Organizations: organizations,
+		NextPageToken: nextPageToken,
+	}, nil
+}
+
+func (s *Store) GetOrganization(ctx context.Context, req *backendv1.GetOrganizationRequest) (*openauthv1.Organization, error) {
+	_, q, _, rollback, err := s.tx(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer rollback()
+
+	organizationId, err := idformat.Organization.Parse(req.Id)
+	if err != nil {
+		return nil, fmt.Errorf("parse organization id: %w", err)
+	}
+
+	organization, err := q.GetOrganizationByProjectIDAndID(ctx, queries.GetOrganizationByProjectIDAndIDParams{
+		ProjectID: authn.ProjectID(ctx),
+		ID:        organizationId,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("get organization: %w", err)
+	}
+
+	return parseOrganization(organization), nil
+}
 
 func (s *Store) CreateOrganization(ctx context.Context, req *backendv1.CreateOrganizationRequest) (*openauthv1.Organization, error) {
 	_, q, commit, rollback, err := s.tx(ctx)
@@ -40,121 +101,6 @@ func (s *Store) CreateOrganization(ctx context.Context, req *backendv1.CreateOrg
 	return parseOrganization(qOrg), nil
 }
 
-func (s *Store) GetOrganization(
-	ctx context.Context,
-	req *backendv1.GetOrganizationRequest,
-) (*openauthv1.Organization, error) {
-	_, q, _, rollback, err := s.tx(ctx)
-	if err != nil {
-		return nil, err
-	}
-	defer rollback()
-
-	organizationId, err := idformat.Organization.Parse(req.Id)
-	if err != nil {
-		return nil, err
-	}
-
-	organization, err := q.GetOrganizationByID(ctx, organizationId)
-	if err != nil {
-		return nil, err
-	}
-
-	return parseOrganization(organization), nil
-}
-
-func (s *Store) ListFrontendOrganizations(
-	ctx context.Context,
-	req *frontendv1.ListOrganizationsRequest,
-) (*frontendv1.ListOrganizationsResponse, error) {
-	_, q, _, rollback, err := s.tx(ctx)
-	if err != nil {
-		return nil, err
-	}
-	defer rollback()
-
-	projectId, err := idformat.Project.Parse(req.ProjectId)
-	if err != nil {
-		return nil, err
-	}
-
-	limit := 10
-	organizationRecords, err := q.ListOrganizationsByProjectIdAndEmail(ctx, queries.ListOrganizationsByProjectIdAndEmailParams{
-		ProjectID:     projectId,
-		VerifiedEmail: &req.Email,
-		Limit:         int32(limit + 1),
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	organizations := []*openauthv1.Organization{}
-	for _, organization := range organizationRecords {
-		organizations = append(organizations, &openauthv1.Organization{
-			Id:          organization.ID.String(),
-			DisplayName: organization.DisplayName,
-		})
-	}
-
-	var nextPageToken string
-	if len(organizations) == limit+1 {
-		nextPageToken = s.pageEncoder.Marshal(organizations[limit].Id)
-		organizations = organizations[:limit]
-	}
-
-	return &frontendv1.ListOrganizationsResponse{
-		Organizations: organizations,
-		NextPageToken: nextPageToken,
-	}, nil
-}
-
-// TODO: Ensure that this function can only be called via a backend service reuqest
-func (s *Store) ListOrganizations(
-	ctx context.Context,
-	req *backendv1.ListOrganizationsRequest,
-) (*backendv1.ListOrganizationsResponse, error) {
-	_, q, _, rollback, err := s.tx(ctx)
-	if err != nil {
-		return nil, err
-	}
-	defer rollback()
-
-	projectId, err := idformat.Project.Parse(req.ProjectId)
-	if err != nil {
-		return nil, err
-	}
-
-	var startID uuid.UUID
-	if err := s.pageEncoder.Unmarshal(req.PageToken, &startID); err != nil {
-		return nil, err
-	}
-
-	limit := 10
-	organizationRecords, err := q.ListOrganizationsByProjectId(ctx, queries.ListOrganizationsByProjectIdParams{
-		ProjectID: projectId,
-		Limit:     int32(limit + 1),
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	organizations := []*openauthv1.Organization{}
-	for _, organization := range organizationRecords {
-		organizations = append(organizations, parseOrganization(organization))
-	}
-
-	var nextPageToken string
-	if len(organizations) == limit+1 {
-		nextPageToken = s.pageEncoder.Marshal(organizations[limit].Id)
-		organizations = organizations[:limit]
-	}
-
-	return &backendv1.ListOrganizationsResponse{
-		Organizations: organizations,
-		NextPageToken: nextPageToken,
-	}, nil
-}
-
 func (s *Store) UpdateOrganization(ctx context.Context, req *backendv1.UpdateOrganizationRequest) (*openauthv1.Organization, error) {
 	_, q, commit, rollback, err := s.tx(ctx)
 	if err != nil {
@@ -164,12 +110,15 @@ func (s *Store) UpdateOrganization(ctx context.Context, req *backendv1.UpdateOrg
 
 	organizationId, err := idformat.Organization.Parse(req.Id)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("parse organization id: %w", err)
 	}
 
-	existingOrganization, err := q.GetOrganizationByID(ctx, organizationId)
-	if err != nil {
-		return nil, err
+	// fetch existing org; this also acts as a permission check
+	if _, err := q.GetOrganizationByProjectIDAndID(ctx, queries.GetOrganizationByProjectIDAndIDParams{
+		ProjectID: authn.ProjectID(ctx),
+		ID:        organizationId,
+	}); err != nil {
+		return nil, fmt.Errorf("get organization: %w", err)
 	}
 
 	updates := queries.UpdateOrganizationParams{
@@ -181,28 +130,31 @@ func (s *Store) UpdateOrganization(ctx context.Context, req *backendv1.UpdateOrg
 		updates.DisplayName = req.Organization.DisplayName
 	}
 
-	// Conditionally update login method configs
-	if req.Organization.GoogleHostedDomain != "" {
-		updates.GoogleHostedDomain = &req.Organization.GoogleHostedDomain
-	}
-	if req.Organization.MicrosoftTenantId != "" {
-		updates.MicrosoftTenantID = &req.Organization.MicrosoftTenantId
-	}
-
-	// Conditionally update overrides
-	if req.Organization.OverrideLogInWithGoogleEnabled != *existingOrganization.OverrideLogInWithGoogleEnabled {
-		updates.OverrideLogInWithGoogleEnabled = &req.Organization.OverrideLogInWithGoogleEnabled
-	}
-	if req.Organization.OverrideLogInWithMicrosoftEnabled != *existingOrganization.OverrideLogInWithMicrosoftEnabled {
-		updates.OverrideLogInWithMicrosoftEnabled = &req.Organization.OverrideLogInWithMicrosoftEnabled
-	}
-	if req.Organization.OverrideLogInWithPasswordEnabled != *existingOrganization.OverrideLogInWithPasswordEnabled {
-		updates.OverrideLogInWithPasswordEnabled = &req.Organization.OverrideLogInWithPasswordEnabled
-	}
+	// TODO these don't work (nil deref), but I don't think they have the right
+	// schema design anyway; skip for now
+	//
+	//// Conditionally update login method configs
+	//if req.Organization.GoogleHostedDomain != "" {
+	//	updates.GoogleHostedDomain = &req.Organization.GoogleHostedDomain
+	//}
+	//if req.Organization.MicrosoftTenantId != "" {
+	//	updates.MicrosoftTenantID = &req.Organization.MicrosoftTenantId
+	//}
+	//
+	//// Conditionally update overrides
+	//if req.Organization.OverrideLogInWithGoogleEnabled != *existingOrganization.OverrideLogInWithGoogleEnabled {
+	//	updates.OverrideLogInWithGoogleEnabled = &req.Organization.OverrideLogInWithGoogleEnabled
+	//}
+	//if req.Organization.OverrideLogInWithMicrosoftEnabled != *existingOrganization.OverrideLogInWithMicrosoftEnabled {
+	//	updates.OverrideLogInWithMicrosoftEnabled = &req.Organization.OverrideLogInWithMicrosoftEnabled
+	//}
+	//if req.Organization.OverrideLogInWithPasswordEnabled != *existingOrganization.OverrideLogInWithPasswordEnabled {
+	//	updates.OverrideLogInWithPasswordEnabled = &req.Organization.OverrideLogInWithPasswordEnabled
+	//}
 
 	updatedOrganization, err := q.UpdateOrganization(ctx, updates)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("update organization: %w", err)
 	}
 
 	if err := commit(); err != nil {

--- a/internal/store/queries/queries.sql.go
+++ b/internal/store/queries/queries.sql.go
@@ -647,6 +647,37 @@ func (q *Queries) GetOrganizationByID(ctx context.Context, id uuid.UUID) (Organi
 	return i, err
 }
 
+const getOrganizationByProjectIDAndID = `-- name: GetOrganizationByProjectIDAndID :one
+SELECT
+    id, project_id, display_name, override_log_in_with_password_enabled, override_log_in_with_google_enabled, override_log_in_with_microsoft_enabled, google_hosted_domain, microsoft_tenant_id
+FROM
+    organizations
+WHERE
+    id = $1
+    AND project_id = $2
+`
+
+type GetOrganizationByProjectIDAndIDParams struct {
+	ID        uuid.UUID
+	ProjectID uuid.UUID
+}
+
+func (q *Queries) GetOrganizationByProjectIDAndID(ctx context.Context, arg GetOrganizationByProjectIDAndIDParams) (Organization, error) {
+	row := q.db.QueryRow(ctx, getOrganizationByProjectIDAndID, arg.ID, arg.ProjectID)
+	var i Organization
+	err := row.Scan(
+		&i.ID,
+		&i.ProjectID,
+		&i.DisplayName,
+		&i.OverrideLogInWithPasswordEnabled,
+		&i.OverrideLogInWithGoogleEnabled,
+		&i.OverrideLogInWithMicrosoftEnabled,
+		&i.GoogleHostedDomain,
+		&i.MicrosoftTenantID,
+	)
+	return i, err
+}
+
 const getProjectAPIKeyBySecretTokenSHA256 = `-- name: GetProjectAPIKeyBySecretTokenSHA256 :one
 SELECT
     id, project_id, create_time, revoked, secret_token_sha256

--- a/sqlc/queries.sql
+++ b/sqlc/queries.sql
@@ -113,6 +113,15 @@ FROM
 WHERE
     id = $1;
 
+-- name: GetOrganizationByProjectIDAndID :one
+SELECT
+    *
+FROM
+    organizations
+WHERE
+    id = $1
+    AND project_id = $2;
+
 -- name: GetProjectByID :one
 SELECT
     *


### PR DESCRIPTION
This PR adds an end-to-end, dumbed-down, working implementation of ListOrganizations, GetOrganization, and UpdateOrganization. 

In particular, we don't yet have answers for how to use this code from the frontend API -- we don't have the authn ctx stuff in place for that.

I also don't opt to implement Update logic for the organizations stuff, because I think we're going to change the schema there anyway; we can make all the columns for overrides non-null, and then rely on a separate boolean that controls whether to use the overrides at all?

```
curl -H "Authorization: Bearer openauth_secret_key_4z1zmme3wawwmagdowl60gv5a" -H "content-type: application/json" http://localhost:3001/backend/v1/organizations | jq
```

```json
{
  "organizations": [
    {
      "id": "org_1idxpmyoksnwoh05c67uolq2t",
      "projectId": "project_cyhg0fd3m5rfsbgh2p9xt3775",
      "displayName": "BBB"
    },
    {
      "id": "org_32ldbjxwhvs5jw0o4birsna8z",
      "projectId": "project_cyhg0fd3m5rfsbgh2p9xt3775",
      "displayName": "OpenAuth"
    }
  ]
}
```

```
curl -H "Authorization: Bearer openauth_secret_key_4z1zmme3wawwmagdowl60gv5a" -H "content-type: application/json" http://localhost:3001/backend/v1/organizations/org_1idxpmyoksnwoh05c67uolq2t -X PATCH -d '{"displayName": "CCC"}' | jq
```

```json
{
  "id": "org_1idxpmyoksnwoh05c67uolq2t",
  "projectId": "project_cyhg0fd3m5rfsbgh2p9xt3775",
  "displayName": "CCC"
}
```

```
curl -H "Authorization: Bearer openauth_secret_key_4z1zmme3wawwmagdowl60gv5a" -H "content-type: application/json" http://localhost:3001/backend/v1/organizations/org_1idxpmyoksnwoh05c67uolq2t | jq
```

```json
{
  "id": "org_1idxpmyoksnwoh05c67uolq2t",
  "projectId": "project_cyhg0fd3m5rfsbgh2p9xt3775",
  "displayName": "CCC"
}
```