### PR TITLE
Add JWKS endpoint

### DIFF
--- a/app/src/gen/openauth/v1/openauth_pb.ts
+++ b/app/src/gen/openauth/v1/openauth_pb.ts
@@ -4,7 +4,7 @@
 // @ts-nocheck
 
 import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
-import { Message, proto3, protoInt64 } from "@bufbuild/protobuf";
+import { Message, proto3, protoInt64, Struct } from "@bufbuild/protobuf";
 
 /**
  * @generated from message openauth.v1.Organization
@@ -201,6 +201,55 @@ export class Project extends Message<Project> {
 
   static equals(a: Project | PlainMessage<Project> | undefined, b: Project | PlainMessage<Project> | undefined): boolean {
     return proto3.util.equals(Project, a, b);
+  }
+}
+
+/**
+ * @generated from message openauth.v1.SessionSigningKey
+ */
+export class SessionSigningKey extends Message<SessionSigningKey> {
+  /**
+   * @generated from field: string id = 1;
+   */
+  id = "";
+
+  /**
+   * @generated from field: string project_id = 2;
+   */
+  projectId = "";
+
+  /**
+   * @generated from field: google.protobuf.Struct public_key_jwk = 3;
+   */
+  publicKeyJwk?: Struct;
+
+  constructor(data?: PartialMessage<SessionSigningKey>) {
+    super();
+    proto3.util.initPartial(data, this);
+  }
+
+  static readonly runtime: typeof proto3 = proto3;
+  static readonly typeName = "openauth.v1.SessionSigningKey";
+  static readonly fields: FieldList = proto3.util.newFieldList(() => [
+    { no: 1, name: "id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+    { no: 2, name: "project_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+    { no: 3, name: "public_key_jwk", kind: "message", T: Struct },
+  ]);
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): SessionSigningKey {
+    return new SessionSigningKey().fromBinary(bytes, options);
+  }
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): SessionSigningKey {
+    return new SessionSigningKey().fromJson(jsonValue, options);
+  }
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): SessionSigningKey {
+    return new SessionSigningKey().fromJsonString(jsonString, options);
+  }
+
+  static equals(a: SessionSigningKey | PlainMessage<SessionSigningKey> | undefined, b: SessionSigningKey | PlainMessage<SessionSigningKey> | undefined): boolean {
+    return proto3.util.equals(SessionSigningKey, a, b);
   }
 }
 

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -24,6 +24,7 @@ import (
 	"github.com/openauth/openauth/internal/hexkey"
 	"github.com/openauth/openauth/internal/intermediateservice"
 	"github.com/openauth/openauth/internal/loadenv"
+	"github.com/openauth/openauth/internal/oauthservice"
 	"github.com/openauth/openauth/internal/pagetoken"
 	"github.com/openauth/openauth/internal/secretload"
 	"github.com/openauth/openauth/internal/slogcorrelation"
@@ -139,6 +140,10 @@ func main() {
 		panic(err)
 	}
 
+	oauthService := oauthservice.Service{
+		Store: store_,
+	}
+
 	// Register health checks
 	mux := http.NewServeMux()
 	mux.Handle("/internal/health", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -150,6 +155,9 @@ func main() {
 	mux.Handle("/backend/v1/", backendTranscoder)
 	mux.Handle("/frontend/v1/", frontendTranscoder)
 	mux.Handle("/intermediate/v1/", intermediateTranscoder)
+
+	// Register oauthservice
+	mux.Handle("/oauth/", oauthService.Handler())
 
 	// Serve the services
 	slog.Info("serve")

--- a/internal/proto/openauth/v1/openauth.proto
+++ b/internal/proto/openauth/v1/openauth.proto
@@ -50,6 +50,12 @@ message Project {
   string microsoft_oauth_client_secret = 9;
 }
 
+message SessionSigningKey {
+  string id = 1;
+  string project_id = 2;
+  google.protobuf.Struct public_key_jwk = 3;
+}
+
 message SessionClaims {
   // The organization ID the session is scoped to.
   string organization_id = 1;

--- a/internal/store/bootstrap.go
+++ b/internal/store/bootstrap.go
@@ -136,7 +136,7 @@ func (s *Store) CreateDogfoodProject(ctx context.Context) (*CreateDogfoodProject
 	}
 
 	// Store the encrypted key in the database
-	sessionSigningKey, err := q.CreateIntermediateSessionSigningKey(ctx, queries.CreateIntermediateSessionSigningKeyParams{
+	sessionSigningKey, err := q.CreateSessionSigningKey(ctx, queries.CreateSessionSigningKeyParams{
 		ID:                   uuid.New(),
 		ProjectID:            dogfoodProjectID,
 		ExpireTime:           &expiresAt,

--- a/sqlc/queries.sql
+++ b/sqlc/queries.sql
@@ -146,16 +146,13 @@ FROM
 WHERE
     id = $1;
 
--- name: GetSessionSigningKeyByProjectID :one
+-- name: GetSessionSigningKeysByProjectID :many
 SELECT
     *
 FROM
     session_signing_keys
 WHERE
-    project_id = $1
-ORDER BY
-    create_time DESC
-LIMIT 1;
+    project_id = $1;
 
 -- name: GetOrganizationByGoogleHostedDomain :one
 SELECT

--- a/sqlc/schema.sql
+++ b/sqlc/schema.sql
@@ -3,7 +3,7 @@
 --
 
 -- Dumped from database version 15.8 (Debian 15.8-1.pgdg120+1)
--- Dumped by pg_dump version 17.0
+-- Dumped by pg_dump version 17.0 (Homebrew)
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;
@@ -16,6 +16,22 @@ SET check_function_bodies = false;
 SET xmloption = content;
 SET client_min_messages = warning;
 SET row_security = off;
+
+--
+-- Name: public; Type: SCHEMA; Schema: -; Owner: postgres
+--
+
+-- *not* creating schema, since initdb creates it
+
+
+ALTER SCHEMA public OWNER TO postgres;
+
+--
+-- Name: SCHEMA public; Type: COMMENT; Schema: -; Owner: postgres
+--
+
+COMMENT ON SCHEMA public IS '';
+
 
 --
 -- Name: auth_method; Type: TYPE; Schema: public; Owner: postgres
@@ -396,6 +412,13 @@ ALTER TABLE ONLY public.sessions
 
 ALTER TABLE ONLY public.users
     ADD CONSTRAINT users_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES public.organizations(id);
+
+
+--
+-- Name: SCHEMA public; Type: ACL; Schema: -; Owner: postgres
+--
+
+REVOKE USAGE ON SCHEMA public FROM PUBLIC;
 
 
 --


### PR DESCRIPTION
This PR adds a public endpoint for getting the session signing keys for a project in JWKS format. This will be used by clients to authenticate sessions from their backend.

I opt to implement this in a new "oauthservice" HTTP server. I do this because 1) this endpoint is weird; it doesn't want any authentication at all, and probably wants to be specially cached by a CDN down the line, and 2) it fits most naturally as part of an overall project-level OAuth authorization server.

I opt to change the store layer method for getting public keys to return a set of them, and make the store layer be in charge of converting keys to their standardized representation.