### PR TITLE
Add CI checks for `make proto` and `make queries`

### DIFF
--- a/sqlc/queries.sql
+++ b/sqlc/queries.sql
@@ -42,7 +42,8 @@ SELECT
 FROM
     organizations
 WHERE
-    id = $1;
+    id = $1
+    AND project_id = $2;
 
 -- name: GetProjectByID :one
 SELECT
@@ -165,3 +166,4 @@ FROM
 WHERE
     revoked = FALSE
     AND refresh_token_sha256 = $1;
+


### PR DESCRIPTION
This PR adds CI checks that ensure that `make proto` and `make queries` don't result in any `git diff` changes. 

Technically, it's not `make queries` but its underlying `sqlc` invocation that is checked. There's so pgformat stuff in `make queries` that I don't want to wrap into what is otherwise a super fast CI check. The existing pgformat-lint CI check is still there to check for bad changes to that file.