### PR TITLE
[OPEN-31] Add SAML initialization endpoint

### DIFF
--- a/internal/saml/store/init.go
+++ b/internal/saml/store/init.go
@@ -1,0 +1,43 @@
+package store
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/openauth/openauth/internal/projectid"
+	"github.com/openauth/openauth/internal/saml/store/queries"
+	"github.com/openauth/openauth/internal/store/idformat"
+)
+
+type SAMLConnectionInitData struct {
+	SPEntityID     string
+	IDPRedirectURL string
+}
+
+func (s *Store) GetSAMLConnectionInitData(ctx context.Context, samlConnectionID string) (*SAMLConnectionInitData, error) {
+	_, q, _, rollback, err := s.tx(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer rollback()
+
+	samlConnectionUUID, err := idformat.SAMLConnection.Parse(samlConnectionID)
+	if err != nil {
+		return nil, fmt.Errorf("parse saml connection id: %w", err)
+	}
+
+	qSAMLConnection, err := q.GetSAMLConnection(ctx, queries.GetSAMLConnectionParams{
+		ProjectID: projectid.ProjectID(ctx),
+		ID:        samlConnectionUUID,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("get saml connection: %w", err)
+	}
+
+	spEntityID := fmt.Sprintf("http://localhost:3001/saml/v1/%s", samlConnectionID) // todo
+
+	return &SAMLConnectionInitData{
+		SPEntityID:     spEntityID,
+		IDPRedirectURL: *qSAMLConnection.IdpRedirectUrl,
+	}, nil
+}


### PR DESCRIPTION
This PR adds an endpoint that browsers can visit to initiate a SAML login. We could have implemented this with an intermediate API of some sort, but this is simpler to integrate against.

```
curl -H "content-type: application/json" -H "X-TODO-OpenAuth-Project-ID: project_b8b1sswcix4ad7bj1b9gfekfj" http://localhost:3001/saml/v1/saml_connection_6l6cp1cpjlpuwms88viabxc73/init

<html>
	<body>
		<form method="POST" action="https://dev-92254632.okta.com/app/dev-92254632_ucarionoktatmp_1/exkig8gdo63cjI4OD5d7/sso/saml">
			<input type="hidden" name="SAMLRequest" value="PEF1dGhuUmVxdWVzdCB4bWxucz0idXJuOm9hc2lzOm5hbWVzOnRjOlNBTUw6Mi4wOnByb3RvY29sIiBJRD0iYmIyMjlmYjktNmVmMS00Y2JlLTliNGUtOTQxM2JmODliMGM1IiBWZXJzaW9uPSIyLjAiIElzc3VlSW5zdGFudD0iMjAyNC0xMi0xMFQxNzoyNzoyMS4yNjlaIj48SXNzdWVyIHhtbG5zPSJ1cm46b2FzaXM6bmFtZXM6dGM6U0FNTDoyLjA6YXNzZXJ0aW9uIj5odHRwOi8vbG9jYWxob3N0OjMwMDEvc2FtbC92MS9zYW1sX2Nvbm5lY3Rpb25fNmw2Y3AxY3BqbHB1d21zODh2aWFieGM3MzwvSXNzdWVyPjwvQXV0aG5SZXF1ZXN0Pg=="></input>
		</form>
		<script>
			document.forms[0].submit();
		</script>
	</body>
</html>
```