### PR TITLE
[HOTFIX] - Use updated make command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: dev
 dev:
-	docker-compose up --build --watch
+	docker compose up --build --watch
 
 .PHONY: queries
 queries:


### PR DESCRIPTION
The latest versions of Docker desktop don't include a separate `docker-compose` command in favor of `docker compose` this just updates our Makefile to use `docker compose`.