### PR TITLE
Fixes to make intermediate-issued sessions work with the backend

### DIFF
--- a/internal/intermediate/store/sessions.go
+++ b/internal/intermediate/store/sessions.go
@@ -211,8 +211,8 @@ func (s *Store) ExchangeIntermediateSessionForSession(ctx context.Context, req *
 		ID:              idformat.User.Format(qUser.ID),
 		CreateTime:      *qUser.CreateTime,
 		Email:           qUser.Email,
-		GoogleUserID:    *qUser.GoogleUserID,
-		MicrosoftUserID: *qUser.MicrosoftUserID,
+		GoogleUserID:    derefOrEmpty(qUser.GoogleUserID),
+		MicrosoftUserID: derefOrEmpty(qUser.MicrosoftUserID),
 		UpdateTime:      derefOrEmpty(qUser.UpdateTime),
 	}, *sessionSigningKeyID, privateKey)
 	if err != nil {

--- a/internal/sessions/sessions.go
+++ b/internal/sessions/sessions.go
@@ -27,12 +27,12 @@ type sessionClaims struct {
 }
 
 type Organization struct {
-	ID          string
+	ID          string `json:"id"`
 	DisplayName string
 }
 
 type Project struct {
-	ID         string
+	ID         string `json:"id"`
 	CreateTime time.Time
 }
 
@@ -45,7 +45,7 @@ type Session struct {
 }
 
 type User struct {
-	ID              string
+	ID              string `json:"id"`
 	CreateTime      time.Time
 	Email           string
 	GoogleUserID    string


### PR DESCRIPTION
This PR makes intermediate-issued sessions work with the backend interceptor.

I am not making any claims as to whether the sessions module or the backend interceptor are good at this time. I suspect we'll end up making changes to both in the future. Instead, I'm just trying to make these things talk to each other succesfully.