### PR TITLE
[OPEN-59] Prevent project API keys from CRUDing other project API keys

### DIFF
--- a/internal/backend/authn/authn.go
+++ b/internal/backend/authn/authn.go
@@ -34,6 +34,14 @@ func NewDogfoodSessionContext(ctx context.Context, dogfoodSession DogfoodSession
 	return context.WithValue(ctx, ctxKey{}, ContextData{DogfoodSession: &dogfoodSession})
 }
 
+func GetContextData(ctx context.Context) ContextData {
+	v, ok := ctx.Value(ctxKey{}).(ContextData)
+	if !ok {
+		panic("ctx does not carry authn data")
+	}
+	return v
+}
+
 func ProjectID(ctx context.Context) uuid.UUID {
 	v, ok := ctx.Value(ctxKey{}).(ContextData)
 	if !ok {


### PR DESCRIPTION
This PR makes the backend CRUD endpoints for project API keys require that the caller be a dogfood session.

Here's such a session still working:

```console
$ curl -s -H "X-TODO-OpenAuth-Project-ID: project_83wam2axr3rfdkt0g85to4w0i" -H "content-type: application/json" -H "authorization: Bearer eyJraWQiOiJzZXNzaW9uX3NpZ25pbmdfa2V5X2U0bmw4eDI3M3h0cWh1dXZrajR5MGN3b3ciLCJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJUT0RPIiwic3ViIjoidXNlcl8zZHJ0ZGlybHF0MHkzbXc0NWNzZnc4dng4IiwiYXVkIjoiVE9ETyIsImV4cCI6MTczNjAzNzUxNCwibmJmIjoxNzM2MDM3MjE0LCJpYXQiOjE3MzYwMzcyMTQsInNlc3Npb24iOnsiSUQiOiJzZXNzaW9uXzJzcXZ2NmljbXpidnY1dmZyNXRkMzRnZ2wiLCJDcmVhdGVUaW1lIjoiMjAyNS0wMS0wNVQwMDozMzozNC4zNDkwMjRaIiwiRXhwaXJlVGltZSI6IjIwMjUtMDEtMTJUMDA6MzM6MzQuMzU1NzA4WiIsIlVzZXJJRCI6InVzZXJfM2RydGRpcmxxdDB5M213NDVjc2Z3OHZ4OCIsIlJldm9rZWQiOmZhbHNlfSwidXNlciI6eyJpZCI6InVzZXJfM2RydGRpcmxxdDB5M213NDVjc2Z3OHZ4OCIsIkNyZWF0ZVRpbWUiOiIyMDI1LTAxLTAyVDIzOjQ4OjE5Ljk1NTY5OVoiLCJFbWFpbCI6InJvb3RAb3BlbmF1dGguZXhhbXBsZS5jb20iLCJHb29nbGVVc2VySUQiOiIiLCJNaWNyb3NvZnRVc2VySUQiOiIiLCJVcGRhdGVUaW1lIjoiMDAwMS0wMS0wMVQwMDowMDowMFoifSwib3JnYW5pemF0aW9uIjp7ImlkIjoib3JnXzBudDBhaGJjeXQ5YTl5NHl4cWFuZWVvenQiLCJEaXNwbGF5TmFtZSI6ImZvb2JhciJ9LCJwcm9qZWN0Ijp7ImlkIjoicHJvamVjdF84M3dhbTJheHIzcmZka3QwZzg1dG80dzBpIiwiQ3JlYXRlVGltZSI6IjAwMDEtMDEtMDFUMDA6MDA6MDBaIn19.D5hjW8lvZTc2oloeS_Tw7Vu_epWfvYdDJZEW7Ot0jTRkCKpnnUK7OlfQ73SsmCUe2a7wTJGEealuSXxd7KiSNQ" 'localhost:3001/internal/connect/openauth.backend.v1.BackendService/ListProjectAPIKeys' -d '{}'

{"projectApiKeys":[{"id":"project_api_key_8ptxk3fdrpk5di8ytx8569kcz","projectId":"project_83wam2axr3rfdkt0g85to4w0i
```

But a project API does not work:

```console
curl -s -H "X-TODO-OpenAuth-Project-ID: project_83wam2axr3rfdkt0g85to4w0i" -H "content-type: application/json" -H "authorization: Bearer openauth_secret_key_er5rdn41czbgb78htvcqen2za" 'localhost:3001/internal/connect/openauth.backend.v1.BackendService/ListProjectAPIKeys' -d '{}' -v
*   Trying [::1]:3001...
* Connected to localhost (::1) port 3001
> POST /internal/connect/openauth.backend.v1.BackendService/ListProjectAPIKeys HTTP/1.1
> Host: localhost:3001
> User-Agent: curl/8.4.0
> Accept: */*
> X-TODO-OpenAuth-Project-ID: project_83wam2axr3rfdkt0g85to4w0i
> content-type: application/json
> authorization: Bearer openauth_secret_key_er5rdn41czbgb78htvcqen2za
> Content-Length: 2
> 
< HTTP/1.1 401 Unauthorized
< Accept-Encoding: gzip
< Content-Type: application/json
< Vary: Origin
< Date: Sun, 05 Jan 2025 00:36:00 GMT
< Content-Length: 90
< 
* Connection #0 to host localhost left intact
{"code":"unauthenticated","message":"this endpoint cannot be invoked by project API keys"}                            
```