### PR TITLE
Set OverrideLogInMethods when creating organizations in intermediate sessions

### DIFF
--- a/internal/intermediate/store/queries/queries-intermediate.sql.go
+++ b/internal/intermediate/store/queries/queries-intermediate.sql.go
@@ -128,8 +128,8 @@ func (q *Queries) CreateIntermediateSession(ctx context.Context, arg CreateInter
 }
 
 const createOrganization = `-- name: CreateOrganization :one
-INSERT INTO organizations (id, project_id, display_name, google_hosted_domain, microsoft_tenant_id, override_log_in_with_google_enabled, override_log_in_with_microsoft_enabled, override_log_in_with_password_enabled)
-    VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+INSERT INTO organizations (id, project_id, display_name, google_hosted_domain, microsoft_tenant_id, override_log_in_methods, override_log_in_with_google_enabled, override_log_in_with_microsoft_enabled, override_log_in_with_password_enabled)
+    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
 RETURNING
     id, project_id, display_name, override_log_in_with_password_enabled, override_log_in_with_google_enabled, override_log_in_with_microsoft_enabled, google_hosted_domain, microsoft_tenant_id, override_log_in_methods
 `
@@ -140,6 +140,7 @@ type CreateOrganizationParams struct {
 	DisplayName                       string
 	GoogleHostedDomain                *string
 	MicrosoftTenantID                 *string
+	OverrideLogInMethods              bool
 	OverrideLogInWithGoogleEnabled    *bool
 	OverrideLogInWithMicrosoftEnabled *bool
 	OverrideLogInWithPasswordEnabled  *bool
@@ -152,6 +153,7 @@ func (q *Queries) CreateOrganization(ctx context.Context, arg CreateOrganization
 		arg.DisplayName,
 		arg.GoogleHostedDomain,
 		arg.MicrosoftTenantID,
+		arg.OverrideLogInMethods,
 		arg.OverrideLogInWithGoogleEnabled,
 		arg.OverrideLogInWithMicrosoftEnabled,
 		arg.OverrideLogInWithPasswordEnabled,

--- a/internal/intermediate/store/sessions.go
+++ b/internal/intermediate/store/sessions.go
@@ -30,11 +30,12 @@ func (s *Store) ExchangeIntermediateSessionForNewOrganizationSession(ctx context
 
 	// Create a new organization
 	qOrganization, err := q.CreateOrganization(ctx, queries.CreateOrganizationParams{
-		ID:                 uuid.New(),
-		ProjectID:          projectID,
-		DisplayName:        req.DisplayName,
-		GoogleHostedDomain: refOrNil(intermediateSession.GoogleHostedDomain),
-		MicrosoftTenantID:  refOrNil(intermediateSession.MicrosoftTenantId),
+		ID:                   uuid.New(),
+		ProjectID:            projectID,
+		DisplayName:          req.DisplayName,
+		GoogleHostedDomain:   refOrNil(intermediateSession.GoogleHostedDomain),
+		MicrosoftTenantID:    refOrNil(intermediateSession.MicrosoftTenantId),
+		OverrideLogInMethods: false,
 	})
 	if err != nil {
 		return nil, err

--- a/sqlc/queries-intermediate.sql
+++ b/sqlc/queries-intermediate.sql
@@ -29,8 +29,8 @@ RETURNING
     *;
 
 -- name: CreateOrganization :one
-INSERT INTO organizations (id, project_id, display_name, google_hosted_domain, microsoft_tenant_id, override_log_in_with_google_enabled, override_log_in_with_microsoft_enabled, override_log_in_with_password_enabled)
-    VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+INSERT INTO organizations (id, project_id, display_name, google_hosted_domain, microsoft_tenant_id, override_log_in_methods, override_log_in_with_google_enabled, override_log_in_with_microsoft_enabled, override_log_in_with_password_enabled)
+    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
 RETURNING
     *;
 


### PR DESCRIPTION
Since `override_log_in_methods` is non-null, we need to include an explicit `false` when creating Organizations via intermediate sessions. 

This PR updates the query for `CreateOrganization` in the `queries-intermediate.sql` file and updates `ExchangeIntermediateSessionForNewOrganizationSession` function to set the value to `false` on create.