### PR TITLE
Use view state for login flow

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -5,21 +5,17 @@ import { BrowserRouter } from 'react-router-dom'
 import { Transport } from '@connectrpc/connect'
 import { TransportProvider } from '@connectrpc/connect-query'
 import { createConnectTransport } from '@connectrpc/connect-web'
-
-import { getIntermediateSessionToken } from './auth'
-
-import LoginPage from '@/pages/LoginPage'
-import NotFoundPage from '@/pages/NotFound'
-import OrganizationsPage from '@/pages/OrganizationsPage'
-import Page from './components/Page'
-import EmailVerificationPage from './pages/EmailVerificationPage'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { API_URL, PROJECT_ID } from './config'
-import GoogleOAuthCallbackPage from './pages/GoogleOAuthCallbackPage'
-import MicrosoftOAuthCallbackPage from './pages/MicrosoftOAuthCallbackPage'
-import CreateOrganizationPage from './pages/CreateOrganizationPage'
-import SessionInfoPage from './pages/SessionInfoPage'
-import PasswordVerificationPage from './pages/PasswordVerificationPage'
+
+import { API_URL, PROJECT_ID } from '@/config'
+
+import GoogleOAuthCallbackPage from '@/pages/GoogleOAuthCallbackPage'
+import LoginPage from '@/pages/LoginPage'
+import MicrosoftOAuthCallbackPage from '@/pages/MicrosoftOAuthCallbackPage'
+import NotFoundPage from '@/pages/NotFound'
+import SessionInfoPage from '@/pages/SessionInfoPage'
+
+import Page from '@/components/Page'
 
 const queryClient = new QueryClient()
 
@@ -48,10 +44,6 @@ const AppWithRoutes: FC = () => {
           <Routes>
             <Route path="/" element={<Page />}>
               <Route
-                path="/create-organization"
-                element={<CreateOrganizationPage />}
-              />
-              <Route
                 path="/google-oauth-callback"
                 element={<GoogleOAuthCallbackPage />}
               />
@@ -60,15 +52,8 @@ const AppWithRoutes: FC = () => {
                 element={<MicrosoftOAuthCallbackPage />}
               />
               <Route path="/login" element={<LoginPage />} />
-              <Route path="/organizations" element={<OrganizationsPage />} />
               <Route path="/session-info" element={<SessionInfoPage />} />
-              <Route path="/verify-email" element={<EmailVerificationPage />} />
-              <Route
-                path="/:organizationId/verify-password"
-                element={<PasswordVerificationPage />}
-              />
             </Route>
-
             <Route path="*" element={<NotFoundPage />} />
           </Routes>
         </BrowserRouter>

--- a/ui/src/components/EmailForm.tsx
+++ b/ui/src/components/EmailForm.tsx
@@ -5,6 +5,7 @@ import { useMutation } from '@connectrpc/connect-query'
 import { setIntermediateSessionToken } from '@/auth'
 import { Button } from './ui/button'
 import { signInWithEmail } from '@/gen/openauth/intermediate/v1/intermediate-IntermediateService_connectquery'
+import { LoginViews } from '@/lib/views'
 
 const EmailForm = () => {
   const navigate = useNavigate()
@@ -30,7 +31,12 @@ const EmailForm = () => {
       setIntermediateSessionToken(intermediateSessionToken)
 
       // redirect to challenge page
-      navigate(`/verify-email?challenge_id=${challengeId}`)
+      navigate(`/login`, {
+        state: {
+          view: LoginViews.EmailVerification,
+          challengeId,
+        },
+      })
     } catch (error) {
       console.error(error)
     }

--- a/ui/src/lib/views.ts
+++ b/ui/src/lib/views.ts
@@ -1,0 +1,7 @@
+export enum LoginViews {
+  CreateOrganization = 'create-organization',
+  Login = 'login',
+  EmailVerification = 'email-verification',
+  Organizations = 'organizations',
+  PasswordVerification = 'password-verification',
+}

--- a/ui/src/pages/GoogleOAuthCallbackPage.tsx
+++ b/ui/src/pages/GoogleOAuthCallbackPage.tsx
@@ -7,6 +7,7 @@ import {
   whoami,
 } from '@/gen/openauth/intermediate/v1/intermediate-IntermediateService_connectquery'
 import { useMutation, useQuery } from '@connectrpc/connect-query'
+import { LoginViews } from '@/lib/views'
 
 const GoogleOAuthCallbackPage = () => {
   const navigate = useNavigate()
@@ -41,7 +42,9 @@ const GoogleOAuthCallbackPage = () => {
 
           // If the user has verified their email, navigate to the organizations page.
           if (data.isEmailVerified) {
-            navigate('/organizations')
+            navigate('/login', {
+              state: { view: LoginViews.Organizations },
+            })
             return
           }
 
@@ -55,9 +58,13 @@ const GoogleOAuthCallbackPage = () => {
           }
 
           // Navigate to the email verification page.
-          navigate(
-            `/verify-email?challenge_id=${emailVerificationChallengeResponse.emailVerificationChallengeId}`,
-          )
+          navigate(`/login`, {
+            state: {
+              view: LoginViews.EmailVerification,
+              challengeId:
+                emailVerificationChallengeResponse.emailVerificationChallengeId,
+            },
+          })
         } catch (error) {
           // TODO: Handle errors on screen once an error handling strategy is in place.
           console.error(error)

--- a/ui/src/pages/LoginPage.tsx
+++ b/ui/src/pages/LoginPage.tsx
@@ -1,96 +1,25 @@
-import React, { useEffect } from 'react'
+import React, { useState } from 'react'
 
-import EmailForm from '@/components/EmailForm'
-import OAuthButton, { OAuthMethods } from '@/components/OAuthButton'
-import { Title } from '@/components/Title'
-import {
-  Card,
-  CardContent,
-  CardFooter,
-  CardHeader,
-  CardTitle,
-} from '@/components/ui/card'
-import TextDivider from '@/components/ui/TextDivider'
-import { useMutation } from '@connectrpc/connect-query'
-
-import { setIntermediateSessionToken } from '@/auth'
-import {
-  getGoogleOAuthRedirectURL,
-  getMicrosoftOAuthRedirectURL,
-} from '@/gen/openauth/intermediate/v1/intermediate-IntermediateService_connectquery'
+import { LoginViews } from '@/lib/views'
+import { useLocation } from 'react-router'
+import CreateOrganization from '@/views/CreateOrganization'
+import Organizations from '@/views/Organizations'
+import EmailVerification from '@/views/EmailVerification'
+import Login from '@/views/Login'
+import PasswordVerification from '@/views/PasswordVerification'
 
 const LoginPage = () => {
-  const googleOAuthRedirectUrlMutation = useMutation(getGoogleOAuthRedirectURL)
-  const microsoftOAuthRedirectUrlMutation = useMutation(
-    getMicrosoftOAuthRedirectURL,
-  )
-
-  const handleGoogleOAuthLogin = async (e: React.MouseEvent) => {
-    e.preventDefault()
-    e.stopPropagation()
-
-    try {
-      const { intermediateSessionToken, url } =
-        await googleOAuthRedirectUrlMutation.mutateAsync({
-          redirectUrl: `${window.location.origin}/google-oauth-callback`,
-        })
-
-      setIntermediateSessionToken(intermediateSessionToken)
-      window.location.href = url
-    } catch (error) {
-      // TODO: Handle errors on screen once an error handling strategy is in place.
-      console.error(error)
-    }
-  }
-
-  const handleMicrosoftOAuthLogin = async (e: React.MouseEvent) => {
-    e.preventDefault()
-    e.stopPropagation()
-
-    try {
-      const { intermediateSessionToken, url } =
-        await microsoftOAuthRedirectUrlMutation.mutateAsync({
-          redirectUrl: `${window.location.origin}/microsoft-oauth-callback`,
-        })
-
-      setIntermediateSessionToken(intermediateSessionToken)
-      window.location.href = url
-    } catch (error) {
-      // TODO: Handle errors on screen once an error handling strategy is in place.
-      console.error(error)
-    }
-  }
+  const location = useLocation()
+  const { view = LoginViews.Login } =
+    (location.state as { view: LoginViews }) || {}
 
   return (
     <>
-      <Title title="Login" />
-
-      <Card className="w-[clamp(320px,50%,420px)]">
-        <CardHeader>
-          <CardTitle className="text-center uppercase text-foreground font-semibold text-sm tracking-wide mt-2">
-            Log In with oAuth
-          </CardTitle>
-        </CardHeader>
-        <CardContent className="flex flex-col items-center w-full">
-          <OAuthButton
-            className="mb-4 w-[clamp(240px,50%,100%)]"
-            method={OAuthMethods.google}
-            onClick={handleGoogleOAuthLogin}
-            variant="outline"
-          />
-          <OAuthButton
-            className="w-[clamp(240px,50%,100%)]"
-            method={OAuthMethods.microsoft}
-            onClick={handleMicrosoftOAuthLogin}
-            variant="outline"
-          />
-
-          <TextDivider text="or" />
-
-          <EmailForm />
-        </CardContent>
-        <CardFooter></CardFooter>
-      </Card>
+      {view === LoginViews.CreateOrganization && <CreateOrganization />}
+      {view === LoginViews.EmailVerification && <EmailVerification />}
+      {view === LoginViews.Login && <Login />}
+      {view === LoginViews.Organizations && <Organizations />}
+      {view === LoginViews.PasswordVerification && <PasswordVerification />}
     </>
   )
 }

--- a/ui/src/pages/MicrosoftOAuthCallbackPage.tsx
+++ b/ui/src/pages/MicrosoftOAuthCallbackPage.tsx
@@ -7,6 +7,7 @@ import {
   whoami,
 } from '@/gen/openauth/intermediate/v1/intermediate-IntermediateService_connectquery'
 import { useMutation, useQuery } from '@connectrpc/connect-query'
+import { LoginViews } from '@/lib/views'
 
 const MicrosoftOAuthCallbackPage = () => {
   const navigate = useNavigate()
@@ -37,14 +38,21 @@ const MicrosoftOAuthCallbackPage = () => {
           }
 
           if (data.isEmailVerified) {
-            navigate('/organizations')
+            navigate('/login', {
+              state: { view: LoginViews.Organizations },
+            })
             return
           }
 
           const { emailVerificationChallengeId } =
             await issueEmailVerificationChallengeMutation.mutateAsync({})
 
-          navigate(`/verify-email?challenge_id=${emailVerificationChallengeId}`)
+          navigate(`/login`, {
+            state: {
+              view: LoginViews.EmailVerification,
+              challengeId: emailVerificationChallengeId,
+            },
+          })
         } catch (error) {
           // TODO: Handle errors on screen once an error handling strategy is in place.
           console.error(error)

--- a/ui/src/views/CreateOrganization.tsx
+++ b/ui/src/views/CreateOrganization.tsx
@@ -12,9 +12,8 @@ import { exchangeIntermediateSessionForNewOrganizationSession } from '@/gen/open
 import { useMutation } from '@connectrpc/connect-query'
 import React, { useState } from 'react'
 import { useNavigate } from 'react-router'
-import { useSearchParams } from 'react-router-dom'
 
-const CreateOrganizationPage = () => {
+const CreateOrganization = () => {
   const navigate = useNavigate()
 
   const [displayName, setDisplayName] = useState<string>('')
@@ -74,4 +73,4 @@ const CreateOrganizationPage = () => {
   )
 }
 
-export default CreateOrganizationPage
+export default CreateOrganization

--- a/ui/src/views/EmailVerification.tsx
+++ b/ui/src/views/EmailVerification.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react'
-import { useNavigate, useSearchParams } from 'react-router-dom'
+import { useLocation, useNavigate } from 'react-router-dom'
 import { useMutation, useQuery } from '@connectrpc/connect-query'
 
 import { Title } from '@/components/Title'
@@ -15,13 +15,13 @@ import {
   verifyEmailChallenge,
   whoami,
 } from '@/gen/openauth/intermediate/v1/intermediate-IntermediateService_connectquery'
+import { LoginViews } from '@/lib/views'
 
-const EmailVerificationPage = () => {
+const EmailVerification = () => {
   const navigate = useNavigate()
-  const [searchParams] = useSearchParams()
+  const { state } = useLocation()
 
   const [challengeCode, setChallengeCode] = useState<string>('')
-  const [challengeId, setChallengeId] = useState<string>('')
   const [email, setEmail] = useState<string>('')
 
   const { data: whoamiRes } = useQuery(whoami)
@@ -31,31 +31,18 @@ const EmailVerificationPage = () => {
     e.preventDefault()
 
     try {
-      const response = await verifyEmailChallengeMutation.mutateAsync({
-        emailVerificationChallengeId: challengeId,
+      await verifyEmailChallengeMutation.mutateAsync({
+        emailVerificationChallengeId: state?.challengeId,
         code: challengeCode,
       })
 
-      console.log('response: ', response)
-
-      navigate('/organizations')
+      navigate('/login', {
+        state: { view: LoginViews.Organizations },
+      })
     } catch (error) {
       console.error(error)
     }
   }
-
-  useEffect(() => {
-    ;(async () => {
-      try {
-        const challengeId = searchParams.get('challenge_id')
-        if (challengeId) {
-          setChallengeId(challengeId)
-        }
-      } catch (error) {
-        console.error(error)
-      }
-    })()
-  }, [])
 
   return (
     <>
@@ -94,4 +81,4 @@ const EmailVerificationPage = () => {
   )
 }
 
-export default EmailVerificationPage
+export default EmailVerification

--- a/ui/src/views/Login.tsx
+++ b/ui/src/views/Login.tsx
@@ -1,0 +1,98 @@
+import React, { useEffect } from 'react'
+
+import EmailForm from '@/components/EmailForm'
+import OAuthButton, { OAuthMethods } from '@/components/OAuthButton'
+import { Title } from '@/components/Title'
+import {
+  Card,
+  CardContent,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card'
+import TextDivider from '@/components/ui/TextDivider'
+import { useMutation } from '@connectrpc/connect-query'
+
+import { setIntermediateSessionToken } from '@/auth'
+import {
+  getGoogleOAuthRedirectURL,
+  getMicrosoftOAuthRedirectURL,
+} from '@/gen/openauth/intermediate/v1/intermediate-IntermediateService_connectquery'
+
+const Login = () => {
+  const googleOAuthRedirectUrlMutation = useMutation(getGoogleOAuthRedirectURL)
+  const microsoftOAuthRedirectUrlMutation = useMutation(
+    getMicrosoftOAuthRedirectURL,
+  )
+
+  const handleGoogleOAuthLogin = async (e: React.MouseEvent) => {
+    e.preventDefault()
+    e.stopPropagation()
+
+    try {
+      const { intermediateSessionToken, url } =
+        await googleOAuthRedirectUrlMutation.mutateAsync({
+          redirectUrl: `${window.location.origin}/google-oauth-callback`,
+        })
+
+      setIntermediateSessionToken(intermediateSessionToken)
+      window.location.href = url
+    } catch (error) {
+      // TODO: Handle errors on screen once an error handling strategy is in place.
+      console.error(error)
+    }
+  }
+
+  const handleMicrosoftOAuthLogin = async (e: React.MouseEvent) => {
+    e.preventDefault()
+    e.stopPropagation()
+
+    try {
+      const { intermediateSessionToken, url } =
+        await microsoftOAuthRedirectUrlMutation.mutateAsync({
+          redirectUrl: `${window.location.origin}/microsoft-oauth-callback`,
+        })
+
+      setIntermediateSessionToken(intermediateSessionToken)
+      window.location.href = url
+    } catch (error) {
+      // TODO: Handle errors on screen once an error handling strategy is in place.
+      console.error(error)
+    }
+  }
+
+  return (
+    <>
+      <Title title="Login" />
+
+      <Card className="w-[clamp(320px,50%,420px)]">
+        <CardHeader>
+          <CardTitle className="text-center uppercase text-foreground font-semibold text-sm tracking-wide mt-2">
+            Log In with oAuth
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="flex flex-col items-center w-full">
+          <OAuthButton
+            className="mb-4 w-[clamp(240px,50%,100%)]"
+            method={OAuthMethods.google}
+            onClick={handleGoogleOAuthLogin}
+            variant="outline"
+          />
+          <OAuthButton
+            className="w-[clamp(240px,50%,100%)]"
+            method={OAuthMethods.microsoft}
+            onClick={handleMicrosoftOAuthLogin}
+            variant="outline"
+          />
+
+          <TextDivider text="or" />
+
+          <EmailForm />
+        </CardContent>
+        <CardFooter></CardFooter>
+      </Card>
+    </>
+  )
+}
+
+export default Login

--- a/ui/src/views/Organizations.tsx
+++ b/ui/src/views/Organizations.tsx
@@ -18,8 +18,9 @@ import {
 import { Link, useNavigate } from 'react-router-dom'
 import { Button } from '@/components/ui/button'
 import { setAccessToken, setRefreshToken } from '@/auth'
+import { LoginViews } from '@/lib/views'
 
-const OrganizationsPage = () => {
+const Organizations = () => {
   const navigate = useNavigate()
 
   const [organizations, setOrganizations] = React.useState<Organization[]>([])
@@ -48,9 +49,6 @@ const OrganizationsPage = () => {
 
   const handleOrganizationClick = async (organization: Organization) => {
     try {
-      console.log(`whoamiRes`, whoamiRes)
-      console.log(`organization`, organization)
-
       // Check if the user is logging in with an email address and the organization supports passwords
       if (
         !whoamiRes?.googleUserId &&
@@ -58,7 +56,12 @@ const OrganizationsPage = () => {
         whoamiRes?.email &&
         organization.logInWithPasswordEnabled
       ) {
-        navigate(`/${organization.id}/verify-password`)
+        navigate(`/login`, {
+          state: {
+            view: LoginViews.PasswordVerification,
+            organizationId: organization.id,
+          },
+        })
         return
       }
 
@@ -117,7 +120,11 @@ const OrganizationsPage = () => {
         <CardFooter>
           <p className="text-sm text-center w-full">
             Or you can{' '}
-            <Link className="text-primary underline" to="/create-organization">
+            <Link
+              className="text-primary underline"
+              to="/login"
+              state={{ view: LoginViews.CreateOrganization }}
+            >
               create an organization
             </Link>
             .
@@ -128,4 +135,4 @@ const OrganizationsPage = () => {
   )
 }
 
-export default OrganizationsPage
+export default Organizations

--- a/ui/src/views/PasswordVerification.tsx
+++ b/ui/src/views/PasswordVerification.tsx
@@ -7,12 +7,12 @@ import {
   verifyPassword,
 } from '@/gen/openauth/intermediate/v1/intermediate-IntermediateService_connectquery'
 import { useMutation } from '@connectrpc/connect-query'
-import { useNavigate, useParams } from 'react-router'
+import { useLocation, useNavigate, useParams } from 'react-router'
 import { setAccessToken, setRefreshToken } from '@/auth'
 
-const PasswordVerificationPage = () => {
+const PasswordVerification = () => {
   const navigate = useNavigate()
-  const params = useParams()
+  const { state } = useLocation()
   const [password, setPassword] = useState<string>('')
 
   const exchangeIntermediateSessionForSessionMutation = useMutation(
@@ -26,12 +26,12 @@ const PasswordVerificationPage = () => {
     try {
       await verifyPasswordMutation.mutateAsync({
         password,
-        organizationId: params.organizationId,
+        organizationId: state?.organizationId,
       })
 
       const { accessToken, refreshToken } =
         await exchangeIntermediateSessionForSessionMutation.mutateAsync({
-          organizationId: params.organizationId,
+          organizationId: state?.organizationId,
         })
 
       setAccessToken(accessToken)
@@ -80,4 +80,4 @@ const PasswordVerificationPage = () => {
   )
 }
 
-export default PasswordVerificationPage
+export default PasswordVerification


### PR DESCRIPTION
This PR updates the login flow use view state for rendering login flow views instead of separate routes.

One caveat here is that Google and Microsoft require their own routes for callback routes and session info is left as a separate page since it will be removed soon.