### PR TITLE
[OPEN-83] Set refresh cookies on exchange

### DIFF
--- a/internal/intermediate/service/sessions.go
+++ b/internal/intermediate/service/sessions.go
@@ -17,6 +17,7 @@ func (s *Service) ExchangeIntermediateSessionForNewOrganizationSession(ctx conte
 
 	connectResponse := connect.NewResponse(res)
 	connectResponse.Header().Add("Set-Cookie", cookies.BuildCookie(ctx, req, "accessToken", res.AccessToken))
+	connectResponse.Header().Add("Set-Cookie", cookies.BuildCookie(ctx, req, "refreshToken", res.RefreshToken))
 
 	return connectResponse, nil
 }
@@ -29,6 +30,7 @@ func (s *Service) ExchangeIntermediateSessionForSession(ctx context.Context, req
 
 	connectResponse := connect.NewResponse(res)
 	connectResponse.Header().Add("Set-Cookie", cookies.BuildCookie(ctx, req, "accessToken", res.AccessToken))
+	connectResponse.Header().Add("Set-Cookie", cookies.BuildCookie(ctx, req, "refreshToken", res.RefreshToken))
 
 	return connectResponse, nil
 }


### PR DESCRIPTION
This PR sets cookies for `refreshTokens` when an intermediate session is exchanged for a session.