### PR TITLE
Clean up docker-compose env vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,7 @@ API_SERVE_ADDR=0.0.0.0:3001
 API_SESSION_KMS_KEY_ID=bc436485-5092-42b8-92a3-0aa8b93536dc
 API_UI_URL=http://auth.tesseral.example.com
 
+APP_BUILD_IS_DEV=1
 APP_API_URL=http://auth.app.tesseral.example.com
 APP_PROJECT_ID=project_XXXXXXXXXXXXXXXXXXXXXXXXXX
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -18,10 +18,8 @@ services:
     tty: true
   app:
     command: bash -c "npm i --force && npm run dev"
-    environment:
-      APP_API_URL: ${APP_API_URL}
-      APP_BUILD_IS_DEV: 1
-      APP_DOGFOOD_PROJECT_ID: ${APP_DOGFOOD_PROJECT_ID}
+    env_file:
+      - .env
     expose:
       - 3000
     image: node:22.11.0
@@ -63,9 +61,7 @@ services:
   ui:
     command: bash -c "npm i --force && npm run dev"
     environment:
-      UI_API_URL: ${UI_API_URL}
       UI_BUILD_IS_DEV: 1
-      UI_PROJECT_ID: ${UI_PROJECT_ID}
     expose:
       - 3002
     image: node:22.11.0


### PR DESCRIPTION
This PR just does some cleanup to the `docker-compose.yaml` to simplify the environment variable inheritance from the `.env` file for `app` and to no longer include unused `ui` environment variables.