### PR TITLE
[OPEN-78] Add saml buttons after email input

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -18,6 +18,7 @@
         "@tanstack/react-query": "^5.62.7",
         "express": "^4.21.1",
         "highlight.js": "^11.10.0",
+        "lodash.debounce": "^4.0.8",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-helmet": "^6.1.0",
@@ -27,6 +28,7 @@
       "devDependencies": {
         "@tailwindcss/forms": "^0.5.9",
         "@tailwindcss/typography": "^0.5.15",
+        "@types/lodash.debounce": "^4.0.9",
         "@types/react": "^18.3.12",
         "@types/react-dom": "^18.3.1",
         "@types/react-helmet": "^6.1.11",
@@ -624,6 +626,23 @@
       "version": "7.0.15",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/lodash": {
+      "version": "4.17.14",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.14.tgz",
+      "integrity": "sha512-jsxagdikDiDBeIRaPYtArcT8my4tN1og7MtMRquFT3XNA6axxyHDRUemqDz/taRDdOUn0GnGHRCuff4q48sW9A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/lodash.debounce": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/lodash.debounce/-/lodash.debounce-4.0.9.tgz",
+      "integrity": "sha512-Ma5JcgTREwpLRwMM+XwBR7DaWe96nC38uCBDFKZWbNKD+osjVzdpnUSwBcqCptrp16sSOLBAUb50Car5I0TCsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/lodash": "*"
+      }
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.13",
@@ -3189,6 +3208,12 @@
       "resolved": "https://registry.npmjs.org/lodash.castarray/-/lodash.castarray-4.4.0.tgz",
       "integrity": "sha512-aVx8ztPv7/2ULbArGJ2Y42bG1mEQ5mGjpdvrbJcJFU3TbYybe+QlLS4pst9zV52ymy2in1KpFPiZnAOATxD4+Q==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.debounce": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
+      "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
       "license": "MIT"
     },
     "node_modules/lodash.isplainobject": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -30,6 +30,7 @@
     "@tanstack/react-query": "^5.62.7",
     "express": "^4.21.1",
     "highlight.js": "^11.10.0",
+    "lodash.debounce": "^4.0.8",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-helmet": "^6.1.0",
@@ -39,6 +40,7 @@
   "devDependencies": {
     "@tailwindcss/forms": "^0.5.9",
     "@tailwindcss/typography": "^0.5.15",
+    "@types/lodash.debounce": "^4.0.9",
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",
     "@types/react-helmet": "^6.1.11",

--- a/ui/src/components/EmailForm.tsx
+++ b/ui/src/components/EmailForm.tsx
@@ -1,21 +1,53 @@
-import React, { ChangeEvent, FormEvent, useEffect, useState } from 'react'
+import React, {
+  ChangeEvent,
+  FormEvent,
+  useCallback,
+  useEffect,
+  useState,
+} from 'react'
 import { useNavigate } from 'react-router'
 import { useMutation } from '@connectrpc/connect-query'
+import debounce from 'lodash.debounce'
 
 import { setIntermediateSessionToken } from '@/auth'
 import { Button } from './ui/button'
-import { signInWithEmail } from '@/gen/openauth/intermediate/v1/intermediate-IntermediateService_connectquery'
+import {
+  listSAMLOrganizations,
+  signInWithEmail,
+} from '@/gen/openauth/intermediate/v1/intermediate-IntermediateService_connectquery'
 import { LoginViews } from '@/lib/views'
+import { Organization } from '@/gen/openauth/intermediate/v1/intermediate_pb'
+import TextDivider from './ui/TextDivider'
 
 const EmailForm = () => {
   const navigate = useNavigate()
+  const emailRegex = /^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,6}$/i
   const signInWithEmailMutation = useMutation(signInWithEmail)
+  const listSAMLOrganizationsMutation = useMutation(listSAMLOrganizations)
 
   const [email, setEmail] = useState<string>('')
   const [emailIsValid, setEmailIsValid] = useState<boolean>(false)
+  const [samlOrganizations, setSamlOrganizations] = useState<Organization[]>([])
+
+  const fetchSamlOrganizations = useCallback(
+    debounce(async () => {
+      const { organizations } = await listSAMLOrganizationsMutation.mutateAsync(
+        {
+          email,
+        },
+      )
+
+      setSamlOrganizations(organizations)
+    }, 300),
+    [email],
+  )
 
   const handleEmail = (e: ChangeEvent<HTMLInputElement>) => {
     setEmail(e.target.value)
+  }
+
+  const handleSAMLLogin = async (samlConnectId: string) => {
+    location.href = `/api/saml/v1/${samlConnectId}/init`
   }
 
   const handleSubmit = async (e: FormEvent) => {
@@ -43,30 +75,59 @@ const EmailForm = () => {
   }
 
   useEffect(() => {
-    const emailRegex = /^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,6}$/
-    setEmailIsValid(emailRegex.test(email))
+    const valid = emailRegex.test(email)
+    setEmailIsValid(valid)
+
+    if (valid) {
+      fetchSamlOrganizations()
+    }
   }, [email])
 
   return (
-    <form className="flex flex-col justify-center" onSubmit={handleSubmit}>
-      <label
-        className="text-center uppercase text-foreground font-semibold text-sm mb-6 tracking-wide"
-        htmlFor="email"
-      >
-        Continue with Email
-      </label>
-      <input
-        className="text-sm rounded border border-border focus:border-primary w-[clamp(240px,50%,100%)] mb-2"
-        id="email"
-        type="email"
-        onChange={handleEmail}
-        placeholder="jane.doe@email.com"
-        value={email}
-      />
-      <Button type="submit" disabled={!emailIsValid}>
-        Sign In
-      </Button>
-    </form>
+    <>
+      <form className="flex flex-col justify-center" onSubmit={handleSubmit}>
+        <label
+          className="text-center uppercase text-foreground font-semibold text-sm mb-6 tracking-wide"
+          htmlFor="email"
+        >
+          Continue with Email
+        </label>
+        <input
+          className="text-sm rounded border border-border focus:border-primary w-[clamp(240px,50%,100%)] mb-2"
+          id="email"
+          type="email"
+          onChange={handleEmail}
+          placeholder="jane.doe@email.com"
+          value={email}
+        />
+        <Button type="submit" disabled={!emailIsValid}>
+          Sign In
+        </Button>
+      </form>
+
+      {samlOrganizations && samlOrganizations.length > 0 && (
+        <>
+          <TextDivider text="or" />
+
+          {samlOrganizations.map((organization) => (
+            <div key={organization.id} className="flex flex-col items-center">
+              <label
+                className="text-center uppercase text-foreground font-semibold text-sm mb-3 tracking-wide w-full"
+                htmlFor="email"
+              >
+                Continue with SAML
+              </label>
+              <a
+                href={`/api/saml/v1/${organization.primarySamlConnectionId}/init`}
+                className="w-full"
+              >
+                <Button variant="outline">{organization.displayName}</Button>
+              </a>
+            </div>
+          ))}
+        </>
+      )}
+    </>
   )
 }
 

--- a/ui/src/components/Page.tsx
+++ b/ui/src/components/Page.tsx
@@ -3,7 +3,7 @@ import { Outlet } from 'react-router'
 
 const Page = () => {
   return (
-    <div className="container mx-auto flex flex-col justify-center items-center h-screen">
+    <div className="container mx-auto flex flex-col justify-center items-center h-screen py-8">
       <div className="flex justify-center">
         <div className="mb-8">
           {/* TODO: Make this conditionally load an Organizations configured logo */}


### PR DESCRIPTION
This PR adds support for fetching SAML-enabled organizations after a valid email is entered into the login with email input on the UI's login page.
![Screenshot 2025-01-14 at 5 11 46 PM](https://github.com/user-attachments/assets/797bc904-69a7-4a33-b12a-7c900e7e7591)
