### PR TITLE
Add basic listing/viewing of all resources (except intermediate sessions)

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -11,6 +11,9 @@ import { ListOrganizationsPage } from '@/pages/organizations/ListOrganizationsPa
 import { useAccessToken } from '@/lib/use-access-token'
 import { Container } from '@/pages/Container'
 import { ViewOrganizationPage } from '@/pages/organizations/ViewOrganizationPage'
+import { ViewUserPage } from '@/pages/users/ViewUserPage'
+import { ListProjectAPIKeysPage } from '@/pages/project-api-keys/ListProjectAPIKeysPage'
+import { ViewProjectPage } from '@/pages/project/ViewProjectPage'
 
 const queryClient = new QueryClient()
 
@@ -43,13 +46,24 @@ function AppWithinQueryClient() {
       <BrowserRouter>
         <Routes>
           <Route path="" element={<Container />}>
+            <Route path="/" element={<ViewProjectPage />} />
+
+            <Route
+              path="/project-api-keys"
+              element={<ListProjectAPIKeysPage />}
+            />
+
             <Route path="/organizations" element={<ListOrganizationsPage />} />
             <Route
               path="/organizations/:organizationId"
               element={<ViewOrganizationPage />}
             />
+
+            <Route
+              path="/organizations/:organizationId/users/:userId"
+              element={<ViewUserPage />}
+            />
           </Route>
-          <Route path="/" element={<SessionInfoPage />} />
           <Route path="*" element={<NotFoundPage />} />
         </Routes>
       </BrowserRouter>

--- a/app/src/pages/organizations/ViewOrganizationPage.tsx
+++ b/app/src/pages/organizations/ViewOrganizationPage.tsx
@@ -40,6 +40,68 @@ export function ViewOrganizationPage() {
         {getOrganizationResponse?.organization?.displayName}
       </h1>
 
+      <div>ID: {organizationId}</div>
+
+      {getOrganizationResponse?.organization && (
+        <div>
+          <div>
+            Created At:
+            {DateTime.fromJSDate(
+              timestampDate(getOrganizationResponse.organization.createTime!),
+            ).toRelative()}
+          </div>
+          <div>
+            Updated At:
+            {DateTime.fromJSDate(
+              timestampDate(getOrganizationResponse.organization.updateTime!),
+            ).toRelative()}
+          </div>
+          <div>
+            Override Log in Methods?
+            {getOrganizationResponse.organization.overrideLogInMethods
+              ? 'Yes'
+              : 'No'}
+          </div>
+          <div>
+            Log in with Google?
+            {getOrganizationResponse.organization.logInWithGoogleEnabled
+              ? 'Yes'
+              : 'No'}
+          </div>
+          <div>
+            Override Log in Microsoft?
+            {getOrganizationResponse.organization.logInWithMicrosoftEnabled
+              ? 'Yes'
+              : 'No'}
+          </div>
+          <div>
+            Override Log in Password?
+            {getOrganizationResponse.organization.logInWithPasswordEnabled
+              ? 'Yes'
+              : 'No'}
+          </div>
+
+          <div>
+            Google Hosted Domain:
+            {getOrganizationResponse.organization.googleHostedDomain}
+          </div>
+          <div>
+            Microsoft Tenant ID:
+            {getOrganizationResponse.organization.microsoftTenantId}
+          </div>
+
+          <div>
+            SAML Enabled?
+            {getOrganizationResponse.organization.samlEnabled}
+          </div>
+
+          <div>
+            SCIM Enabled?
+            {getOrganizationResponse.organization.scimEnabled}
+          </div>
+        </div>
+      )}
+
       <h2 className="font-semibold text-xl">Users</h2>
       <Table className="mt-4">
         <TableHeader>

--- a/app/src/pages/project-api-keys/ListProjectAPIKeysPage.tsx
+++ b/app/src/pages/project-api-keys/ListProjectAPIKeysPage.tsx
@@ -1,0 +1,60 @@
+import { useQuery } from '@connectrpc/connect-query'
+import { listProjectAPIKeys } from '@/gen/openauth/backend/v1/backend-BackendService_connectquery'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+import { Link } from 'react-router-dom'
+import React from 'react'
+import { DateTime } from 'luxon'
+import { timestampDate } from '@bufbuild/protobuf/wkt'
+
+export function ListProjectAPIKeysPage() {
+  const { data: listProjectAPIKeysResponse } = useQuery(listProjectAPIKeys, {})
+
+  return (
+    <div>
+      <h1 className="font-semibold text-xl">Project API Keys</h1>
+      <Table className="mt-4">
+        <TableHeader>
+          <TableRow>
+            <TableCell>Display Name</TableCell>
+            <TableHead>ID</TableHead>
+            <TableHead>Status</TableHead>
+            <TableHead>Created At</TableHead>
+            <TableHead>Updated At</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {listProjectAPIKeysResponse?.projectApiKeys?.map((projectAPIKey) => (
+            <TableRow key={projectAPIKey.id}>
+              <TableCell className="font-medium">
+                <Link to={`/project-api-keys/${projectAPIKey.id}`}>
+                  {projectAPIKey.displayName}
+                </Link>
+              </TableCell>
+              <TableCell className="font-mono">{projectAPIKey.id}</TableCell>
+              <TableCell>
+                {projectAPIKey?.revoked ? 'Revoked' : 'Active'}
+              </TableCell>
+              <TableCell>
+                {DateTime.fromJSDate(
+                  timestampDate(projectAPIKey.createTime!),
+                ).toRelative()}
+              </TableCell>
+              <TableCell>
+                {DateTime.fromJSDate(
+                  timestampDate(projectAPIKey.updateTime!),
+                ).toRelative()}
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  )
+}

--- a/app/src/pages/project/ViewProjectPage.tsx
+++ b/app/src/pages/project/ViewProjectPage.tsx
@@ -1,0 +1,74 @@
+import { useQuery } from '@connectrpc/connect-query'
+import { getProject } from '@/gen/openauth/backend/v1/backend-BackendService_connectquery'
+import React from 'react'
+import { DateTime } from 'luxon'
+import { timestampDate } from '@bufbuild/protobuf/wkt'
+
+export function ViewProjectPage() {
+  const { data: getProjectResponse } = useQuery(getProject, {})
+
+  return (
+    <div>
+      <h1 className="font-semibold text-2xl">
+        {getProjectResponse?.project?.displayName}
+      </h1>
+
+      {getProjectResponse?.project && (
+        <div>
+          <div>ID: {getProjectResponse?.project?.id}</div>
+
+          <div>
+            Created At:
+            {DateTime.fromJSDate(
+              timestampDate(getProjectResponse.project.createTime!),
+            ).toRelative()}
+          </div>
+          <div>
+            Updated At:
+            {DateTime.fromJSDate(
+              timestampDate(getProjectResponse.project.updateTime!),
+            ).toRelative()}
+          </div>
+          <div>
+            Log in with Google Enabled?
+            {getProjectResponse.project.logInWithPasswordEnabled ? 'Yes' : 'No'}
+          </div>
+          <div>
+            Log in with Microsoft Enabled?
+            {getProjectResponse.project.logInWithMicrosoftEnabled
+              ? 'Yes'
+              : 'No'}
+          </div>
+          <div>
+            Log in with Password Enabled?
+            {getProjectResponse.project.logInWithPasswordEnabled ? 'Yes' : 'No'}
+          </div>
+          <div>
+            Google OAuth Client ID:
+            {getProjectResponse.project.googleOauthClientId}
+          </div>
+          <div>
+            Microsoft OAuth Client ID:
+            {getProjectResponse.project.microsoftOauthClientId}
+          </div>
+          <div>
+            Projects have SAML enabled by default:
+            {getProjectResponse.project.organizationsSamlEnabledDefault
+              ? 'Yes'
+              : 'No'}
+          </div>
+          <div>
+            Projects have SCIM enabled by default:
+            {getProjectResponse.project.organizationsScimEnabledDefault
+              ? 'Yes'
+              : 'No'}
+          </div>
+          <div>
+            Auth domain:
+            {getProjectResponse.project.authDomain}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/app/src/pages/users/ViewUserPage.tsx
+++ b/app/src/pages/users/ViewUserPage.tsx
@@ -1,0 +1,65 @@
+import { useParams } from 'react-router'
+import { useQuery } from '@connectrpc/connect-query'
+import {
+  getUser,
+  listSessions,
+} from '@/gen/openauth/backend/v1/backend-BackendService_connectquery'
+import React from 'react'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+import { Link } from 'react-router-dom'
+import { DateTime } from 'luxon'
+import { timestampDate } from '@bufbuild/protobuf/dist/esm/wkt'
+
+export function ViewUserPage() {
+  const { organizationId, userId } = useParams()
+  const { data: getUserResponse } = useQuery(getUser, {
+    id: userId,
+  })
+  const { data: listSessionsResponse } = useQuery(listSessions, {
+    userId,
+  })
+
+  return (
+    <div>
+      <h1 className="text-2xl">{getUserResponse?.user?.email}</h1>
+
+      <div>ID: {getUserResponse?.user?.email}</div>
+      <div>Google user ID: {getUserResponse?.user?.googleUserId}</div>
+      <div>Microsoft user ID: {getUserResponse?.user?.microsoftUserId}</div>
+      <div>Owner? {getUserResponse?.user?.owner ? 'yes' : 'no'}</div>
+
+      <h2 className="font-semibold text-xl">Sessions</h2>
+      <Table className="mt-4">
+        <TableHeader>
+          <TableRow>
+            <TableHead>ID</TableHead>
+            <TableHead>Created At</TableHead>
+            <TableHead>Updated At</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {listSessionsResponse?.sessions?.map((session) => (
+            <TableRow key={session.id}>
+              <TableCell className="font-medium font-mono">
+                <Link
+                  to={`/organizations/${organizationId}/users/${userId}/sessions/${session.id}`}
+                >
+                  {session.id}
+                </Link>
+              </TableCell>
+              <TableCell>TODO</TableCell>
+              <TableCell>TODO</TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  )
+}


### PR DESCRIPTION
This PR adds super-basic, mega-ugly UI stuff to dump CRUD stuff out to HTML. The intention here is to have data in place, and make it easier to see where the design should go.

Sessions, SAML connections, and SCIM API keys aren't given their own view page yet, because they have no sub-resources and so aren't that interesting until we have patterns for updating things.

Intermediate sessions are included here because it's not yet clear to me whether we give them a treatment like the rest of our resources.