### PR TITLE
Fix password verification

### DIFF
--- a/internal/intermediate/store/intermediate_sessions.go
+++ b/internal/intermediate/store/intermediate_sessions.go
@@ -94,7 +94,7 @@ func (s *Store) VerifyPassword(ctx context.Context, req *intermediatev1.VerifyPa
 	}
 
 	if qUser.PasswordBcrypt == nil {
-		return nil, apierror.NewFailedPreconditionError("password not set", fmt.Errorf("password not set"))
+		return nil, apierror.NewFailedPreconditionError("user does not have a password configured", fmt.Errorf("password not set"))
 	}
 
 	// Check password is valid


### PR DESCRIPTION
Our `VerifyPassword` function was missing a check to confirm that the `password_bcrypt` column is set on the user before attempting to match hashes. This PR adds that check.