### PR TITLE
Only permit override_log_in_methods to restrict, not augment, methods

### DIFF
--- a/internal/backend/store/organizations.go
+++ b/internal/backend/store/organizations.go
@@ -287,9 +287,13 @@ func parseOrganization(qProject queries.Project, qOrg queries.Organization) *bac
 	logInWithPasswordEnabled := qProject.LogInWithPasswordEnabled
 
 	if qOrg.OverrideLogInMethods {
-		logInWithGoogleEnabled = derefOrEmpty(qOrg.OverrideLogInWithGoogleEnabled)
-		logInWithMicrosoftEnabled = derefOrEmpty(qOrg.OverrideLogInWithMicrosoftEnabled)
-		logInWithPasswordEnabled = derefOrEmpty(qOrg.OverrideLogInWithPasswordEnabled)
+		// Only allow overrides to restrict settings, not augment them. We can't
+		// easily enforce this rule in UpdateOrganization, because a project may
+		// retroactively remove support for a login method. Such an update
+		// should immediately affect all organizations.
+		logInWithGoogleEnabled = qProject.LogInWithGoogleEnabled && derefOrEmpty(qOrg.OverrideLogInWithGoogleEnabled)
+		logInWithMicrosoftEnabled = qProject.LogInWithMicrosoftEnabled && derefOrEmpty(qOrg.OverrideLogInWithMicrosoftEnabled)
+		logInWithPasswordEnabled = qProject.LogInWithPasswordEnabled && derefOrEmpty(qOrg.OverrideLogInWithPasswordEnabled)
 	}
 
 	return &backendv1.Organization{


### PR DESCRIPTION
This PR fixes a bug in parseOrganization: organizations should not be able to override log in methods to enable support for a login method that the project itself does not have enabled.