### PR TITLE
Move local dev hosts to https

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .local/kms/data
 .local/postgres
 .local/s3
+.local/nginx/*.pem
 node_modules
 /app/public/index.css
 /app/public/index.js

--- a/.local/nginx/default.conf
+++ b/.local/nginx/default.conf
@@ -1,7 +1,9 @@
 server {
-  listen      80;
+  listen 443 ssl;
+  listen [::]:443 ssl;
+  ssl_certificate /etc/nginx/conf.d/api.tesseral.example.com.pem;
+  ssl_certificate_key /etc/nginx/conf.d/api.tesseral.example.com-key.pem;
   server_name api.tesseral.example.com;
-
 
   location / {
     proxy_http_version 1.1;
@@ -21,9 +23,11 @@ server {
 }
 
 server {
-  listen      80;
+  listen 443 ssl;
+  listen [::]:443 ssl;
+  ssl_certificate /etc/nginx/conf.d/app.tesseral.example.com.pem;
+  ssl_certificate_key /etc/nginx/conf.d/app.tesseral.example.com-key.pem;
   server_name app.tesseral.example.com;
-
 
   location / {
     proxy_http_version 1.1;
@@ -42,8 +46,11 @@ server {
 }
 
 server {
-  listen      80;
-  server_name auth.tesseral.example.com auth.app.tesseral.example.com;
+  listen 443 ssl;
+  listen [::]:443 ssl;
+  ssl_certificate /etc/nginx/conf.d/auth.app.tesseral.example.com.pem;
+  ssl_certificate_key /etc/nginx/conf.d/auth.app.tesseral.example.com-key.pem;
+  server_name auth.app.tesseral.example.com;
 
   location / {
     proxy_http_version 1.1;
@@ -78,8 +85,11 @@ server {
 
 
 server {
-    listen      80;
-    server_name tesseralusercontent.example.com;
+  listen 443 ssl;
+  listen [::]:443 ssl;
+  ssl_certificate /etc/nginx/conf.d/tesseralusercontent.example.com.pem;
+  ssl_certificate_key /etc/nginx/conf.d/tesseralusercontent.example.com-key.pem;
+  server_name tesseralusercontent.example.com;
 
     location / {
       proxy_http_version 1.1;

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -30,7 +30,7 @@ function useTransport(): Transport {
   const accessToken = useAccessToken()
 
   return createConnectTransport({
-    baseUrl: `http://auth.app.tesseral.example.com/api/internal/connect`,
+    baseUrl: `https://auth.app.tesseral.example.com/api/internal/connect`,
     fetch: (input, init) =>
       fetch(input, {
         ...init,

--- a/app/src/lib/use-access-token.ts
+++ b/app/src/lib/use-access-token.ts
@@ -2,8 +2,8 @@ import { useMutation } from '@tanstack/react-query'
 import { useState } from 'react'
 
 interface User {
-  id: string;
-  email: string;
+  id: string
+  email: string
 }
 
 export function useUser(): User | undefined {
@@ -12,7 +12,7 @@ export function useUser(): User | undefined {
     return
   }
 
-  const claims = JSON.parse(base64Decode(accessToken.split(".")[1]))
+  const claims = JSON.parse(base64Decode(accessToken.split('.')[1]))
   return {
     id: claims.user.id,
     email: claims.user.email,
@@ -24,14 +24,17 @@ export function useAccessToken(): string | undefined {
   const refresh = useMutation({
     mutationKey: ['refresh'],
     mutationFn: async () => {
-      const response = await fetch(`http://auth.app.tesseral.example.com/api/frontend/v1/access-token`, {
-        credentials: 'include',
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
+      const response = await fetch(
+        `https://auth.app.tesseral.example.com/api/frontend/v1/access-token`,
+        {
+          credentials: 'include',
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: '{}',
         },
-        body: '{}',
-      })
+      )
       return (await response.json()).accessToken
     },
   })
@@ -41,7 +44,7 @@ export function useAccessToken(): string | undefined {
       refresh.mutate(undefined, {
         onSuccess: (accessToken) => {
           setAccessToken(accessToken)
-        }
+        },
       })
     }
   }
@@ -53,7 +56,9 @@ export function useAccessToken(): string | undefined {
 const ACCESS_TOKEN_REFRESH_THRESHOLD_SECONDS = 10
 
 function shouldRefresh(accessToken: string): boolean {
-  const refreshAt = parseAccessTokenExpiration(accessToken) - ACCESS_TOKEN_REFRESH_THRESHOLD_SECONDS
+  const refreshAt =
+    parseAccessTokenExpiration(accessToken) -
+    ACCESS_TOKEN_REFRESH_THRESHOLD_SECONDS
   const now = Math.floor(new Date().getTime() / 1000)
   return refreshAt < now
 }
@@ -63,14 +68,14 @@ function parseAccessTokenExpiration(accessToken: string): number {
 }
 
 function base64Decode(s: string): string {
-  const binaryString = atob(s);
+  const binaryString = atob(s)
 
-  const bytes = new Uint8Array(binaryString.length);
+  const bytes = new Uint8Array(binaryString.length)
   for (let i = 0; i < binaryString.length; i++) {
-    bytes[i] = binaryString.charCodeAt(i);
+    bytes[i] = binaryString.charCodeAt(i)
   }
 
-  return new TextDecoder().decode(bytes);
+  return new TextDecoder().decode(bytes)
 }
 
 function useLocalStorage(

--- a/bin/create-localhost-certs
+++ b/bin/create-localhost-certs
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+create_cert() {
+  mkcert -cert-file .local/nginx/$1.pem -key-file .local/nginx/$1-key.pem $1
+}
+
+create_cert "api.tesseral.example.com"
+create_cert "app.tesseral.example.com"
+create_cert "auth.app.tesseral.example.com"
+create_cert "tesseralusercontent.example.com"

--- a/bin/macos-bootstrap
+++ b/bin/macos-bootstrap
@@ -25,3 +25,10 @@ if ! command -v migrate 2>&1 >/dev/null
 then
   brew install golang-migrate
 fi
+
+if ! command -v mkcert 2>&1 >/dev/null
+then
+  brew install mkcert
+fi
+
+mkcert -install

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -45,9 +45,10 @@ services:
   nginx:
     image: nginx:1-alpine
     ports:
-      - 80:80
+      - "80:80"
+      - "443:443"
     volumes:
-      - ./.local/nginx/local.conf:/etc/nginx/conf.d/default.conf
+      - ./.local/nginx:/etc/nginx/conf.d
   postgres:
     environment:
       POSTGRES_PASSWORD: "password"


### PR DESCRIPTION
This PR moves the local dev experience to running on HTTPS.

We use https://github.com/FiloSottile/mkcert (added to bootstrap-macos) to generate the relevant certificates and the local CA. `./bin/create-localhost-certs` generates these certificates, which are gitignored.

I couldn't quite figure out how to serve both auth.tesseral.example.com and auth.app.tesseral.example.com, so at least for now I opt to only serve the latter. Do we even need the former anymore?

Most noise in the JS in this diff is due to prettier stuff.