### PR TITLE
Component-ify DetailsGrid

### DIFF
--- a/app/src/components/details-grid.tsx
+++ b/app/src/components/details-grid.tsx
@@ -1,0 +1,53 @@
+import * as React from 'react'
+import { cn } from '@/lib/utils'
+
+export const DetailsGrid = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn('text-sm grid grid-flow-col auto-cols-fr gap-x-2', className)}
+    {...props}
+  />
+))
+DetailsGrid.displayName = 'DetailsGrid'
+
+export const DetailsGridColumn = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn(
+      'border-r last:border-r-0 px-4 first:pl-0 last:pr-0 border-gray-200 flex flex-col gap-y-3',
+      className,
+    )}
+    {...props}
+  />
+))
+DetailsGridColumn.displayName = 'DetailsGridColumn'
+
+export const DetailsGridEntry = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div ref={ref} className={cn('', className)} {...props} />
+))
+DetailsGridEntry.displayName = 'DetailsGridEntry'
+
+export const DetailsGridKey = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div ref={ref} className={cn('font-semibold', className)} {...props} />
+))
+DetailsGridKey.displayName = 'DetailsGridKey'
+
+export const DetailsGridValue = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div ref={ref} className={cn('truncate', className)} {...props} />
+))
+DetailsGridValue.displayName = 'DetailsGridValue'

--- a/app/src/pages/saml-connections/ViewSAMLConnectionPage.tsx
+++ b/app/src/pages/saml-connections/ViewSAMLConnectionPage.tsx
@@ -35,6 +35,13 @@ import {
   AlertDialogTitle,
 } from '@/components/ui/alert-dialog'
 import { Button } from '@/components/ui/button'
+import {
+  DetailsGrid,
+  DetailsGridColumn,
+  DetailsGridEntry,
+  DetailsGridKey,
+  DetailsGridValue,
+} from '@/components/details-grid'
 import { PageCodeSubtitle, PageDescription, PageTitle } from '@/components/page'
 
 export function ViewSAMLConnectionPage() {
@@ -105,42 +112,42 @@ export function ViewSAMLConnectionPage() {
           </Button>
         </CardHeader>
         <CardContent>
-          <div className="grid grid-cols-3 gap-x-2 text-sm">
-            <div className="border-r border-gray-200 pr-8 flex flex-col gap-4">
-              <div>
-                <div className="font-semibold">
+          <DetailsGrid>
+            <DetailsGridColumn>
+              <DetailsGridEntry>
+                <DetailsGridKey>
                   Assertion Consumer Service (ACS) URL
-                </div>
-                <div className="truncate">
+                </DetailsGridKey>
+                <DetailsGridValue>
                   {getSAMLConnectionResponse?.samlConnection?.spAcsUrl}
-                </div>
-              </div>
+                </DetailsGridValue>
+              </DetailsGridEntry>
 
-              <div>
-                <div className="font-semibold">SP Entity ID</div>
-                <div className="truncate">
+              <DetailsGridEntry>
+                <DetailsGridKey>SP Entity ID</DetailsGridKey>
+                <DetailsGridValue>
                   {getSAMLConnectionResponse?.samlConnection?.spEntityId}
-                </div>
-              </div>
-            </div>
-            <div className="border-r border-gray-200 pr-8 pl-8 flex flex-col gap-4">
-              <div>
-                <div className="font-semibold">IDP Entity ID</div>
-                <div className="truncate">
+                </DetailsGridValue>
+              </DetailsGridEntry>
+            </DetailsGridColumn>
+            <DetailsGridColumn>
+              <DetailsGridEntry>
+                <DetailsGridKey>IDP Entity ID</DetailsGridKey>
+                <DetailsGridValue>
                   {getSAMLConnectionResponse?.samlConnection?.idpEntityId ||
                     '-'}
-                </div>
-              </div>
-              <div>
-                <div className="font-semibold">IDP Redirect URL</div>
-                <div className="truncate">
+                </DetailsGridValue>
+              </DetailsGridEntry>
+              <DetailsGridEntry>
+                <DetailsGridKey>IDP Redirect URL</DetailsGridKey>
+                <DetailsGridValue>
                   {getSAMLConnectionResponse?.samlConnection?.idpRedirectUrl ||
                     '-'}
-                </div>
-              </div>
-              <div>
-                <div className="font-semibold">IDP Certificate</div>
-                <div>
+                </DetailsGridValue>
+              </DetailsGridEntry>
+              <DetailsGridEntry>
+                <DetailsGridKey>IDP Certificate</DetailsGridKey>
+                <DetailsGridValue>
                   {getSAMLConnectionResponse?.samlConnection
                     ?.idpX509Certificate ? (
                     <a
@@ -153,44 +160,44 @@ export function ViewSAMLConnectionPage() {
                   ) : (
                     '-'
                   )}
-                </div>
-              </div>
-            </div>
-            <div className="border-gray-200 pl-8 flex flex-col gap-4">
-              <div>
-                <div className="font-semibold">Primary</div>
-                <div className="truncate">
+                </DetailsGridValue>
+              </DetailsGridEntry>
+            </DetailsGridColumn>
+            <DetailsGridColumn>
+              <DetailsGridEntry>
+                <DetailsGridKey>Primary</DetailsGridKey>
+                <DetailsGridValue>
                   {getSAMLConnectionResponse?.samlConnection?.primary
                     ? 'Yes'
                     : 'No'}
-                </div>
-              </div>
+                </DetailsGridValue>
+              </DetailsGridEntry>
 
-              <div>
-                <div className="font-semibold">Created</div>
-                <div className="truncate">
+              <DetailsGridEntry>
+                <DetailsGridKey>Created</DetailsGridKey>
+                <DetailsGridValue>
                   {getSAMLConnectionResponse?.samlConnection?.createTime &&
                     DateTime.fromJSDate(
                       timestampDate(
                         getSAMLConnectionResponse?.samlConnection?.createTime,
                       ),
                     ).toRelative()}
-                </div>
-              </div>
+                </DetailsGridValue>
+              </DetailsGridEntry>
 
-              <div>
-                <div className="font-semibold">Updated</div>
-                <div className="truncate">
+              <DetailsGridEntry>
+                <DetailsGridKey>Updated</DetailsGridKey>
+                <DetailsGridValue>
                   {getSAMLConnectionResponse?.samlConnection?.updateTime &&
                     DateTime.fromJSDate(
                       timestampDate(
                         getSAMLConnectionResponse?.samlConnection?.updateTime,
                       ),
                     ).toRelative()}
-                </div>
-              </div>
-            </div>
-          </div>
+                </DetailsGridValue>
+              </DetailsGridEntry>
+            </DetailsGridColumn>
+          </DetailsGrid>
         </CardContent>
       </Card>
 


### PR DESCRIPTION
This PR makes DetailsGrid into a component in the style of shadcn. It also includes tweaks to the spacing for such grids.

![screenshot-2025-01-17-14-42-30](https://github.com/user-attachments/assets/50100a7a-eb57-43b9-9357-701b5438270a)
