### PR TITLE
Add stacked concept for ListOrganizationsPage

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -107,6 +107,7 @@ function AppWithinQueryClient() {
               element={<ViewSCIMAPIKeyPage />}
             />
           </Route>
+
           <Route path="*" element={<NotFoundPage />} />
         </Routes>
       </BrowserRouter>

--- a/app/src/pages/organizations/ListOrganizationsPage.tsx
+++ b/app/src/pages/organizations/ListOrganizationsPage.tsx
@@ -19,56 +19,80 @@ import {
   CardHeader,
   CardTitle,
 } from '@/components/ui/card'
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from '@/components/ui/breadcrumb'
+import { PageDescription, PageTitle } from '@/components/page'
 
 export function ListOrganizationsPage() {
   const { data: listOrganizationsResponse } = useQuery(listOrganizations, {})
 
   return (
-    <Card>
-      <CardHeader>
-        <CardTitle>Organizations</CardTitle>
-        <CardDescription>
-          An organization represents one of your business customers. Lorem ipsum
-          dolor.
-        </CardDescription>
-      </CardHeader>
-      <CardContent>
-        <Table>
-          <TableHeader>
-            <TableRow>
-              <TableHead>Display Name</TableHead>
-              <TableHead>ID</TableHead>
-              <TableHead>Created At</TableHead>
-              <TableHead>Updated At</TableHead>
-            </TableRow>
-          </TableHeader>
-          <TableBody>
-            {listOrganizationsResponse?.organizations?.map((org) => (
-              <TableRow key={org.id}>
-                <TableCell className="font-medium">
-                  <Link
-                    className="underline underline-offset-2 decoration-muted-foreground/40"
-                    to={`/organizations/${org.id}`}
-                  >
-                    {org.displayName}
-                  </Link>
-                </TableCell>
-                <TableCell className="font-mono">{org.id}</TableCell>
-                <TableCell>
-                  {DateTime.fromJSDate(
-                    timestampDate(org.createTime!),
-                  ).toRelative()}
-                </TableCell>
-                <TableCell>
-                  {DateTime.fromJSDate(
-                    timestampDate(org.updateTime!),
-                  ).toRelative()}
-                </TableCell>
+    <div>
+      <Breadcrumb>
+        <BreadcrumbList>
+          <BreadcrumbItem>
+            <BreadcrumbLink asChild>
+              <Link to="/">Home</Link>
+            </BreadcrumbLink>
+          </BreadcrumbItem>
+          <BreadcrumbSeparator />
+          <BreadcrumbItem>
+            <BreadcrumbPage>Organizations</BreadcrumbPage>
+          </BreadcrumbItem>
+        </BreadcrumbList>
+      </Breadcrumb>
+
+      <PageTitle>Organizations</PageTitle>
+      <PageDescription>
+        An organization represents one of your business customers. Lorem ipsum
+        dolor.
+      </PageDescription>
+
+      <Card className="mt-8 overflow-hidden">
+        <CardContent className="-m-6 mt-0">
+          <Table>
+            <TableHeader className="bg-gray-50">
+              <TableRow>
+                <TableHead>Display Name</TableHead>
+                <TableHead>ID</TableHead>
+                <TableHead>Created</TableHead>
+                <TableHead>Updated</TableHead>
               </TableRow>
-            ))}
-          </TableBody>
-        </Table>
-      </CardContent>
-    </Card>
+            </TableHeader>
+            <TableBody>
+              {listOrganizationsResponse?.organizations?.map((org) => (
+                <TableRow key={org.id}>
+                  <TableCell className="font-medium">
+                    <Link
+                      className="underline underline-offset-2 decoration-muted-foreground/40"
+                      to={`/organizations/${org.id}`}
+                    >
+                      {org.displayName}
+                    </Link>
+                  </TableCell>
+                  <TableCell className="font-mono">{org.id}</TableCell>
+                  <TableCell>
+                    {DateTime.fromJSDate(
+                      timestampDate(org.createTime!),
+                    ).toRelative()}
+                  </TableCell>
+                  <TableCell>
+                    {DateTime.fromJSDate(
+                      timestampDate(org.updateTime!),
+                    ).toRelative()}
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </CardContent>
+      </Card>
+    </div>
   )
 }


### PR DESCRIPTION
The main subtlety here is that there's no natural details view for this page. So instead I'm thinking we do an edge-to-edge card/table? Only cards enjamb the fold gracefully.

When we add a button for creating a new org, I figure it goes at the level of the page title, but on the right.

![screenshot-2025-01-17-15-44-15](https://github.com/user-attachments/assets/6cd5c605-f6fc-468e-9bd3-a3d2bb48130c)
