### PR TITLE
[OPEN-124] Rename cookies to be underscore-based, give each cookie type a separate method

### DIFF
--- a/internal/frontend/authn/interceptor/interceptor.go
+++ b/internal/frontend/authn/interceptor/interceptor.go
@@ -40,7 +40,7 @@ func New(s *store.Store, p *projectid.Sniffer, authAppsRootDomain string) connec
 			}
 
 			// get the access token from the cookie to enforce authentication
-			accessToken, err := cookies.GetCookie(ctx, req, "accessToken", *projectID)
+			accessToken, err := cookies.GetAccessToken(*projectID, req)
 			if err != nil {
 				return nil, connect.NewError(connect.CodeUnauthenticated, err)
 			}

--- a/internal/frontend/service/sessions.go
+++ b/internal/frontend/service/sessions.go
@@ -11,7 +11,7 @@ import (
 )
 
 func (s *Service) GetAccessToken(ctx context.Context, req *connect.Request[frontendv1.GetAccessTokenRequest]) (*connect.Response[frontendv1.GetAccessTokenResponse], error) {
-	refreshToken, _ := cookies.GetCookie(ctx, req, "refreshToken", authn.ProjectID(ctx))
+	refreshToken, _ := cookies.GetRefreshToken(authn.ProjectID(ctx), req)
 	if refreshToken != "" {
 		req.Msg.RefreshToken = refreshToken
 	}
@@ -24,7 +24,7 @@ func (s *Service) GetAccessToken(ctx context.Context, req *connect.Request[front
 	connectRes := connect.NewResponse(&frontendv1.GetAccessTokenResponse{
 		AccessToken: accessToken,
 	})
-	connectRes.Header().Add("Set-Cookie", cookies.BuildCookie(ctx, req, "accessToken", accessToken, authn.ProjectID(ctx)))
+	connectRes.Header().Add("Set-Cookie", cookies.NewAccessToken(authn.ProjectID(ctx), accessToken))
 
 	return connectRes, nil
 }

--- a/internal/intermediate/authn/interceptor/interceptor.go
+++ b/internal/intermediate/authn/interceptor/interceptor.go
@@ -40,7 +40,7 @@ func New(s *store.Store, p *projectid.Sniffer, authAppsRootDomain string) connec
 			}
 
 			// Enforce authentication if not skipping
-			secretValue, err := cookies.GetCookie(ctx, req, "intermediateAccessToken", *projectID)
+			secretValue, err := cookies.GetIntermediateAccessToken(*projectID, req)
 			if err != nil {
 				return nil, connect.NewError(connect.CodeUnauthenticated, err)
 			}

--- a/internal/intermediate/service/create.go
+++ b/internal/intermediate/service/create.go
@@ -17,7 +17,7 @@ func (s *Service) CreateIntermediateSession(ctx context.Context, req *connect.Re
 	}
 
 	connectResponse := connect.NewResponse(res)
-	connectResponse.Header().Add("Set-Cookie", cookies.BuildCookie(ctx, req, "intermediateAccessToken", res.IntermediateSessionSecretToken, authn.ProjectID(ctx)))
+	connectResponse.Header().Add("Set-Cookie", cookies.NewIntermediateAccessToken(authn.ProjectID(ctx), res.IntermediateSessionSecretToken))
 
 	return connectResponse, nil
 }

--- a/internal/intermediate/service/exchange.go
+++ b/internal/intermediate/service/exchange.go
@@ -24,8 +24,8 @@ func (s *Service) ExchangeIntermediateSessionForSession(ctx context.Context, req
 	res.AccessToken = accessToken
 
 	connectRes := connect.NewResponse(res)
-	connectRes.Header().Add("Set-Cookie", cookies.BuildCookie(ctx, req, "refreshToken", res.RefreshToken, authn.ProjectID(ctx)))
-	connectRes.Header().Add("Set-Cookie", cookies.BuildCookie(ctx, req, "accessToken", res.AccessToken, authn.ProjectID(ctx)))
+	connectRes.Header().Add("Set-Cookie", cookies.NewRefreshToken(authn.ProjectID(ctx), res.RefreshToken))
+	connectRes.Header().Add("Set-Cookie", cookies.NewRefreshToken(authn.ProjectID(ctx), res.AccessToken))
 	return connectRes, nil
 }
 
@@ -43,7 +43,7 @@ func (s *Service) ExchangeIntermediateSessionForNewOrganizationSession(ctx conte
 	res.AccessToken = accessToken
 
 	connectRes := connect.NewResponse(res)
-	connectRes.Header().Add("Set-Cookie", cookies.BuildCookie(ctx, req, "refreshToken", res.RefreshToken, authn.ProjectID(ctx)))
-	connectRes.Header().Add("Set-Cookie", cookies.BuildCookie(ctx, req, "accessToken", res.AccessToken, authn.ProjectID(ctx)))
+	connectRes.Header().Add("Set-Cookie", cookies.NewRefreshToken(authn.ProjectID(ctx), res.RefreshToken))
+	connectRes.Header().Add("Set-Cookie", cookies.NewRefreshToken(authn.ProjectID(ctx), res.AccessToken))
 	return connectRes, nil
 }


### PR DESCRIPTION
When we add the ability to customize the duration of access tokens and sessions, we may want to have access token cookies never expire (at the browser level; they can expire at the semantic/JWT level). But not doing that now.