### PR TITLE
[FIX] Add bootstrap script

### DIFF
--- a/.local/db/seed.sql
+++ b/.local/db/seed.sql
@@ -17,8 +17,8 @@ INSERT INTO users (id, email, password_bcrypt, organization_id, is_owner)
   VALUES (gen_random_uuid(), 'root@app.tesseral.example.com', crypt('testpassword', gen_salt('bf', 14)), (SELECT id FROM organizations LIMIT 1), true);
 
 -- Create Project UI Settings
-INSERT INTO project_ui_settings (project_id)
-  VALUES ('56bfa2b3-4f5a-4c68-8fc5-db3bf20731a2'::uuid);
+INSERT INTO project_ui_settings (id, project_id)
+  VALUES (gen_random_uuid(), '56bfa2b3-4f5a-4c68-8fc5-db3bf20731a2'::uuid);
 
 -- Create a Dogfood Project API Key
 INSERT INTO project_api_keys (id, project_id, secret_token_sha256, display_name)
@@ -26,4 +26,10 @@ INSERT INTO project_api_keys (id, project_id, secret_token_sha256, display_name)
 
 -- Create a Session Signing Key for the Dogfood Project
 INSERT INTO session_signing_keys (id, project_id, public_key, private_key_cipher_text, expire_time) 
-  VALUES (gen_random_uuid(), '56bfa2b3-4f5a-4c68-8fc5-db3bf20731a2'::uuid, pg_read_binary_file('/tmp/local/session-signing-key.encrypted'), pg_read_binary_file('/tmp/local/session-signing-public-key.pem'), (SELECT NOW() + INTERVAL '1 year'));
+  VALUES (
+    gen_random_uuid(), 
+    '56bfa2b3-4f5a-4c68-8fc5-db3bf20731a2'::uuid, 
+    decode('3059301306072a8648ce3d020106082a8648ce3d03010703420004a82072a20d2217055f0c5f9f9283e128d5bc26334b19024c93f6ad50619bbe83bc565a2fbdc05e02dc3f1452ff273d7ec2534e2cbe7fe395443d887b128dd7b8', 'hex'), 
+    decode('a1931242e0770f54e2e8365053ff4b72dc72faba0830cff2099655d78aa188f750b9b1557e70566f00449fed97a5b8a94a113e8049a6ea71436a08e135f35a7b86863f47f36e3e0b62dad8da491f28aba812a93e7a2a44913c6b2377c7ea4d89991eba682d9cfb17d5bcfa3f608e973dd61aa9910453e8d48058ea80ccbd0d5961de3fd25dcfe893dbdd84a43112d1533b4ebae65e35b0e8eca25b1af53eec97304899cb542ac850e59a6c5521ecbee5549329a451c8c948d82f1d6858a6d2680d987e72945ad5b4166c3529b70ce1106573874fb68847ed823567a9edfeac712d464ac5b339f80365be985ab69703d7100c65c872765b04a9ee575002edadef', 'hex'), 
+    (SELECT NOW() + INTERVAL '1 year')
+  );

--- a/Makefile
+++ b/Makefile
@@ -11,20 +11,10 @@ bootstrap:
 	done
 	@# Run database migrations
 	make migrate up
-	@# Create the tmp directory for ecdsa keys
-	mkdir -p .local/tmp
-	@# Generate the session signing key
-	openssl genpkey -algorithm EC -pkeyopt ec_paramgen_curve:P-256 -out .local/tmp/session-signing-key.pem
-	sed -e '1d' -e '$$d' .local/tmp/session-signing-key.pem > .local/tmp/trimmed-session-signing-key.pem
-	openssl ec -in .local/tmp/session-signing-key.pem -pubout -out .local/tmp/session-signing-public-key.pem
-	@# Encrypt the session signing key with KMS
-	AWS_DEFAULT_REGION=us-west-1 AWS_ACCESS_KEY_ID=test AWS_SECRET_ACCESS_KEY=test aws kms encrypt --encryption-algorithm "RSAES_OAEP_SHA_256" --endpoint-url "http://localhost:4566" --key-id "bc436485-5092-42b8-92a3-0aa8b93536dc" --output text --plaintext fileb://.local/tmp/trimmed-session-signing-key.pem --query CiphertextBlob | base64 -d > .local/tmp/session-signing-key.encrypted
 	@# Seed the database
 	psql "postgres://postgres:password@localhost:5432?sslmode=disable" -f .local/db/seed.sql
 	@# Stop the docker containers
 	docker compose stop
-	@# Remove the tmp directory
-	rm -rf .local/tmp
 
 .PHONY: dev
 dev:


### PR DESCRIPTION
This PR adds the creation of a new `project_ui_settings` record in the `seed.sql` file used by `make bootstrap`.

It also hard-codes the `seed.sql` file to use a static password and signing key values to simplify setup.

This makes the `bootstrap` target much simpler in our `Makefile` as well.

It also updates the auth domains to fix a typo with auth domains.