### PR TITLE
Fix reference to renamed column in intermediate, check proj-level disable

### DIFF
--- a/internal/intermediate/store/exchange.go
+++ b/internal/intermediate/store/exchange.go
@@ -43,6 +43,15 @@ func (s *Store) ExchangeIntermediateSessionForSession(ctx context.Context, req *
 		return nil, err
 	}
 
+	qProject, err := q.GetProjectByID(ctx, authn.ProjectID(ctx))
+	if err != nil {
+		return nil, fmt.Errorf("get project by id: %w", err)
+	}
+
+	if err := enforceProjectLoginEnabled(qProject); err != nil {
+		return nil, fmt.Errorf("enforce project login enabled: %w", err)
+	}
+
 	if err := enforceOrganizationLoginEnabled(qOrg); err != nil {
 		return nil, fmt.Errorf("enforce organization login enabled: %w", err)
 	}

--- a/internal/intermediate/store/queries/queries-intermediate.sql.go
+++ b/internal/intermediate/store/queries/queries-intermediate.sql.go
@@ -775,8 +775,7 @@ FROM
 WHERE
     organizations.project_id = $1
     AND organization_google_hosted_domains.google_hosted_domain = $2
-    AND (organizations.login_disabled IS NULL
-        OR organizations.login_disabled = FALSE)
+    AND NOT organizations.logins_disabled
 `
 
 type ListOrganizationsByGoogleHostedDomainParams struct {
@@ -830,8 +829,7 @@ WHERE
             AND users.google_user_id = $3)
         OR (users.microsoft_user_id IS NOT NULL
             AND users.microsoft_user_id = $4))
-    AND (organizations.login_disabled IS NULL
-        OR organizations.login_disabled = FALSE)
+    AND NOT organizations.logins_disabled
 `
 
 type ListOrganizationsByMatchingUserParams struct {
@@ -888,8 +886,7 @@ FROM
 WHERE
     organizations.project_id = $1
     AND organization_microsoft_tenant_ids.microsoft_tenant_id = $2
-    AND (organizations.login_disabled IS NULL
-        OR organizations.login_disabled = FALSE)
+    AND NOT organizations.logins_disabled
 `
 
 type ListOrganizationsByMicrosoftTenantIDParams struct {

--- a/sqlc/queries-intermediate.sql
+++ b/sqlc/queries-intermediate.sql
@@ -155,8 +155,7 @@ FROM
 WHERE
     organizations.project_id = $1
     AND organization_google_hosted_domains.google_hosted_domain = $2
-    AND (organizations.login_disabled IS NULL
-        OR organizations.login_disabled = FALSE);
+    AND NOT organizations.logins_disabled;
 
 -- name: ListOrganizationsByMicrosoftTenantID :many
 SELECT
@@ -167,8 +166,7 @@ FROM
 WHERE
     organizations.project_id = $1
     AND organization_microsoft_tenant_ids.microsoft_tenant_id = $2
-    AND (organizations.login_disabled IS NULL
-        OR organizations.login_disabled = FALSE);
+    AND NOT organizations.logins_disabled;
 
 -- name: ListOrganizationsByMatchingUser :many
 SELECT
@@ -183,8 +181,7 @@ WHERE
             AND users.google_user_id = $3)
         OR (users.microsoft_user_id IS NOT NULL
             AND users.microsoft_user_id = $4))
-    AND (organizations.login_disabled IS NULL
-        OR organizations.login_disabled = FALSE);
+    AND NOT organizations.logins_disabled;
 
 -- name: ListSAMLOrganizations :many
 SELECT


### PR DESCRIPTION
This PR fixes an issue that breaks main: references to login_disabled, instead of logins_disabled. I also have the exchange endpoint check both orgs and projects, even when exchanging for an existing org.