### PR TITLE
Passkey registration fixes

### DIFF
--- a/internal/intermediate/service/passkeys.go
+++ b/internal/intermediate/service/passkeys.go
@@ -23,3 +23,19 @@ func (s *Service) RegisterPasskey(ctx context.Context, req *connect.Request[inte
 	}
 	return connect.NewResponse(res), nil
 }
+
+func (s *Service) IssuePasskeyChallenge(ctx context.Context, req *connect.Request[intermediatev1.IssuePasskeyChallengeRequest]) (*connect.Response[intermediatev1.IssuePasskeyChallengeResponse], error) {
+	res, err := s.Store.IssuePasskeyChallenge(ctx, req.Msg)
+	if err != nil {
+		return nil, fmt.Errorf("store: %w", err)
+	}
+	return connect.NewResponse(res), nil
+}
+
+func (s *Service) VerifyPasskey(ctx context.Context, req *connect.Request[intermediatev1.VerifyPasskeyRequest]) (*connect.Response[intermediatev1.VerifyPasskeyResponse], error) {
+	res, err := s.Store.VerifyPasskey(ctx, req.Msg)
+	if err != nil {
+		return nil, fmt.Errorf("store: %w", err)
+	}
+	return connect.NewResponse(res), nil
+}

--- a/internal/intermediate/store/passkeys.go
+++ b/internal/intermediate/store/passkeys.go
@@ -72,7 +72,7 @@ func (s *Store) RegisterPasskey(ctx context.Context, req *intermediatev1.Registe
 		return nil, fmt.Errorf("marshal public key: %w", err)
 	}
 
-	if _, err := q.RegisterPasskey(ctx, queries.RegisterPasskeyParams{
+	if _, err := q.UpdateIntermediateSessionRegisterPasskey(ctx, queries.UpdateIntermediateSessionRegisterPasskeyParams{
 		ID:                  authn.IntermediateSessionID(ctx),
 		PasskeyCredentialID: cred.ID,
 		PasskeyPublicKey:    publicKey,

--- a/sqlc/queries-intermediate.sql
+++ b/sqlc/queries-intermediate.sql
@@ -374,7 +374,7 @@ SELECT
         WHERE
             user_id = $1);
 
--- name: RegisterPasskey :one
+-- name: UpdateIntermediateSessionRegisterPasskey :one
 UPDATE
     intermediate_sessions
 SET
@@ -385,6 +385,12 @@ SET
     update_time = now()
 WHERE
     id = $4
+RETURNING
+    *;
+
+-- name: CreatePasskey :one
+INSERT INTO passkeys (id, user_id, credential_id, public_key, aaguid)
+    VALUES ($1, $2, $3, $4, $5)
 RETURNING
     *;
 


### PR DESCRIPTION
This PR adds a missing set of service layer passthroughs, as well as logic to copy over passkeys from intermediate sessions to users. It also renames a confusingly terse query ("RegisterPasskey") to one that is much clearer about what it updates.