### PR TITLE
[OPEN-205] Add log in settings to vault organization settings page

### DIFF
--- a/ui/src/components/DashboardPage/index.tsx
+++ b/ui/src/components/DashboardPage/index.tsx
@@ -13,6 +13,7 @@ import {
 import Header from './Header'
 import { SidebarProvider, SidebarTrigger } from '../ui/sidebar'
 import DashboardSidebar from './DashboardSidebar'
+import { Toaster } from '../ui/sonner'
 
 const DashboardPage: FC<PropsWithChildren> = ({ children }) => {
   const isDarkMode = useDarkMode()
@@ -62,6 +63,7 @@ const DashboardPage: FC<PropsWithChildren> = ({ children }) => {
                   </div>
                 </div>
               </main>
+              <Toaster position="top-center" />
             </SidebarProvider>
           </UserContextProvider>
         </OrganizationContextProvider>

--- a/ui/src/pages/dashboard/EditSAMLConnectionsPage.tsx
+++ b/ui/src/pages/dashboard/EditSAMLConnectionsPage.tsx
@@ -29,6 +29,8 @@ import {
 } from '@/components/ui/form'
 import { Switch } from '@/components/ui/switch'
 import { Input } from '@/components/ui/input'
+import { parseErrorMessage } from '@/lib/errors'
+import { toast } from 'sonner'
 
 const schema = z.object({
   primary: z.boolean(),
@@ -58,17 +60,24 @@ const EditSAMLConnectionsPage: FC = () => {
   const updateSAMLConnectionMutation = useMutation(updateSAMLConnection)
 
   const handleSubmit = async (values: z.infer<typeof schema>) => {
-    await updateSAMLConnectionMutation.mutateAsync({
-      id: params.samlConnectionId,
-      samlConnection: {
-        primary: values.primary,
-        idpEntityId: values.idpEntityId,
-        idpRedirectUrl: values.idpRedirectUrl,
-        idpX509Certificate: values.idpX509Certificate,
-      },
-    })
+    try {
+      await updateSAMLConnectionMutation.mutateAsync({
+        id: params.samlConnectionId,
+        samlConnection: {
+          primary: values.primary,
+          idpEntityId: values.idpEntityId,
+          idpRedirectUrl: values.idpRedirectUrl,
+          idpX509Certificate: values.idpX509Certificate,
+        },
+      })
 
-    navigate(`/organization`)
+      navigate(`/organization`)
+    } catch (error) {
+      const message = parseErrorMessage(error)
+      toast.error('Could not update SAML connection', {
+        description: message,
+      })
+    }
   }
 
   useEffect(() => {

--- a/ui/src/pages/dashboard/OrganizationSettingsPage.tsx
+++ b/ui/src/pages/dashboard/OrganizationSettingsPage.tsx
@@ -28,6 +28,7 @@ import { Link } from 'react-router-dom'
 import { Switch } from '@/components/ui/switch'
 import { parseErrorMessage } from '@/lib/errors'
 import { toast } from 'sonner'
+import Loader from '@/components/ui/loader'
 
 const OrganizationSettingsPage: FC = () => {
   const user = useUser()
@@ -62,6 +63,7 @@ const OrganizationSettingsPage: FC = () => {
   const [requireMFA, setRequireMFA] = useState(
     organizationRes?.organization?.requireMfa,
   )
+  const [submittingLoginSettings, setSubmittingLoginSettings] = useState(false)
 
   const changeUserRole = async (userId: string, isOwner: boolean) => {
     await updateUserMutation.mutateAsync({
@@ -82,24 +84,28 @@ const OrganizationSettingsPage: FC = () => {
   }
 
   const submitLoginSettings = async () => {
+    setSubmittingLoginSettings(true)
     try {
-    await updateOrganizationMutation.mutateAsync({
-      organization: {
-        logInWithEmail,
-        logInWithGoogle,
-        logInWithMicrosoft,
-        logInWithPassword,
-      },
-    })
+      await updateOrganizationMutation.mutateAsync({
+        organization: {
+          logInWithEmail,
+          logInWithGoogle,
+          logInWithMicrosoft,
+          logInWithPassword,
+        },
+      })
 
-    setEditingLoginSettings(false)
-    await refetchOrganization()
-    resetLoginSettings()
-  } catch (error) {
-    const message = parseErrorMessage(error)
-    toast.error('Could not update organization settings', {
-      description: message,
-    })
+      setEditingLoginSettings(false)
+      await refetchOrganization()
+      resetLoginSettings()
+      setSubmittingLoginSettings(false)
+    } catch (error) {
+      setSubmittingLoginSettings(false)
+      const message = parseErrorMessage(error)
+      toast.error('Could not update organization settings', {
+        description: message,
+      })
+    }
   }
 
   useEffect(() => {
@@ -174,7 +180,12 @@ const OrganizationSettingsPage: FC = () => {
                   >
                     Cancel
                   </Button>
-                  <Button className="ml-2" onClick={submitLoginSettings}>
+                  <Button
+                    className="ml-2"
+                    disabled={submittingLoginSettings}
+                    onClick={submitLoginSettings}
+                  >
+                    {submittingLoginSettings && <Loader />}
                     Save
                   </Button>
                 </div>


### PR DESCRIPTION
This PR adds support for managing login settings in the vault Organization Settings page.

![Screenshot 2025-02-06 at 1 33 35 PM](https://github.com/user-attachments/assets/e82af6d5-e26b-42cc-a800-a7927a9685c6)

![Screenshot 2025-02-06 at 1 36 56 PM](https://github.com/user-attachments/assets/7a3a9e41-7a3b-452e-bbf6-cb736fbe674b)

