### PR TITLE
[OPEN-210] Refetch passkeys when a new one is registered

### DIFF
--- a/ui/src/pages/dashboard/UserSettingsPage.tsx
+++ b/ui/src/pages/dashboard/UserSettingsPage.tsx
@@ -194,6 +194,8 @@ const UserSettingsPage: FC = () => {
             .attestationObject,
         ),
       })
+
+      await refetchMyPasskeys()
     } catch (error) {
       const message = parseErrorMessage(error)
       toast.error('Could not register passkey', {


### PR DESCRIPTION
This PR updates the Vault User Settings page to refetch passkeys when a new one is registered.