### PR TITLE
Clean up Vault pages sidebar

### DIFF
--- a/ui/src/components/DashboardPage/DashboardSidebar.tsx
+++ b/ui/src/components/DashboardPage/DashboardSidebar.tsx
@@ -32,7 +32,7 @@ const DashboardSidebar: FC = () => {
   ]
 
   return (
-    <Sidebar>
+    <Sidebar collapsible="icon">
       <SidebarHeader>
         <div>
           {isDarkMode && settings?.detectDarkModeEnabled ? (

--- a/ui/src/components/DashboardPage/index.tsx
+++ b/ui/src/components/DashboardPage/index.tsx
@@ -14,9 +14,11 @@ import Header from './Header'
 import { SidebarProvider, SidebarTrigger } from '../ui/sidebar'
 import DashboardSidebar from './DashboardSidebar'
 import { Toaster } from '../ui/sonner'
+import { useIsMobile } from '@/hooks/use-mobile'
 
 const DashboardPage: FC<PropsWithChildren> = ({ children }) => {
   const isDarkMode = useDarkMode()
+  const isMobile = useIsMobile()
   const settings = useSettings()
   const session = useSession()
 
@@ -56,10 +58,10 @@ const DashboardPage: FC<PropsWithChildren> = ({ children }) => {
                   isDarkMode && settings?.detectDarkModeEnabled ? 'dark' : '',
                 )}
               >
-                <SidebarTrigger />
+                {isMobile && <SidebarTrigger />}
                 <div className="bg-body mx-auto items-center">
                   <div className="mx-auto px-6 lg:px-8">
-                    <div className="pb-8">{children}</div>
+                    <div className="py-8">{children}</div>
                   </div>
                 </div>
               </main>


### PR DESCRIPTION
This PR updates the Vault pages sidebar to only show the trigger on mobile and make sidebar collapse to icons in the event that it collapses.