### PR TITLE
Add login and signup footer to console

### DIFF
--- a/console/src/views/login/StartLoginView.tsx
+++ b/console/src/views/login/StartLoginView.tsx
@@ -7,7 +7,13 @@ import {
   getGoogleOAuthRedirectURL,
   getMicrosoftOAuthRedirectURL,
 } from '@/gen/openauth/intermediate/v1/intermediate-IntermediateService_connectquery'
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import {
+  Card,
+  CardContent,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card'
 import TextDivider from '@/components/ui/text-divider'
 import EmailForm from '@/components/login/EmailForm'
 import { AuthType, useAuthType } from '@/lib/auth'
@@ -15,6 +21,7 @@ import { Title } from '@/components/Title'
 import { parseErrorMessage } from '@/lib/errors'
 import { toast } from 'sonner'
 import useSettings from '@/lib/settings'
+import { Link } from 'react-router-dom'
 
 interface StartLoginViewProps {
   setView: Dispatch<React.SetStateAction<LoginView>>
@@ -130,6 +137,25 @@ const StartLoginView: FC<StartLoginViewProps> = ({ setView }) => {
             </>
           )}
         </CardContent>
+        <CardFooter>
+          <div className="text-sm text-center text-muted-foreground w-full">
+            {authType === AuthType.SignUp ? (
+              <>
+                Already have an account?{' '}
+                <Link className="underline" to="/login">
+                  Log in
+                </Link>
+              </>
+            ) : (
+              <>
+                Don't have an account?{' '}
+                <Link className="underline" to="/signup">
+                  Sign up
+                </Link>
+              </>
+            )}
+          </div>
+        </CardFooter>
       </Card>
     </>
   )


### PR DESCRIPTION
This PR adds a footer to the login and signup pages to toggle back and forth if necessary.

![Screenshot 2025-02-07 at 10 27 13 AM](https://github.com/user-attachments/assets/ba5149d5-da30-48c8-97bd-5f106600b3c2)
![Screenshot 2025-02-07 at 10 27 19 AM](https://github.com/user-attachments/assets/3f3097bd-e824-41ff-8925-81554e7c689e)
