### PR TITLE
Make cookies samesite none

### DIFF
--- a/internal/cookies/cookies.go
+++ b/internal/cookies/cookies.go
@@ -40,6 +40,7 @@ func newCookie(name string, maxAge time.Duration, projectID uuid.UUID, value str
 		Value:    value,
 		MaxAge:   int(maxAge.Seconds()),
 		Path:     "/",
+		SameSite: http.SameSiteNoneMode,
 		Secure:   true,
 		HttpOnly: true,
 	}


### PR DESCRIPTION
This PR updates our cookies to be `SameSite=None` to account for CORS requests coming from non-vault domains.

This should resolve the current issues with console access in dev.