### PR TITLE
Fix display names for intermediate ListOrganizations for dogfood project

### DIFF
--- a/internal/intermediate/store/organizations.go
+++ b/internal/intermediate/store/organizations.go
@@ -161,6 +161,17 @@ func (s *Store) ListOrganizations(ctx context.Context, req *intermediatev1.ListO
 			org.UserHasPasskey = hasPasskeys
 		}
 
+		// if we're servicing the dogfood project, then show the display name of
+		// the project this organization backs
+		if authn.ProjectID(ctx) == *s.dogfoodProjectID {
+			qBackedProject, err := q.GetProjectByBackingOrganizationID(ctx, &qOrg.ID)
+			if err != nil {
+				return nil, fmt.Errorf("get project by backing organization id: %w", err)
+			}
+
+			org.DisplayName = qBackedProject.DisplayName
+		}
+
 		// Append the parsed organization to the list of organizations.
 		organizations = append(organizations, org)
 	}

--- a/internal/intermediate/store/queries/queries-intermediate.sql.go
+++ b/internal/intermediate/store/queries/queries-intermediate.sql.go
@@ -800,6 +800,45 @@ func (q *Queries) GetPasskeyByCredentialID(ctx context.Context, arg GetPasskeyBy
 	return i, err
 }
 
+const getProjectByBackingOrganizationID = `-- name: GetProjectByBackingOrganizationID :one
+SELECT
+    id, organization_id, log_in_with_password, log_in_with_google, log_in_with_microsoft, google_oauth_client_id, microsoft_oauth_client_id, google_oauth_client_secret_ciphertext, microsoft_oauth_client_secret_ciphertext, display_name, create_time, update_time, logins_disabled, log_in_with_authenticator_app, log_in_with_passkey, log_in_with_email, log_in_with_saml, redirect_uri, after_login_redirect_uri, after_signup_redirect_uri, vault_domain, email_send_from_domain
+FROM
+    projects
+WHERE
+    organization_id = $1
+`
+
+func (q *Queries) GetProjectByBackingOrganizationID(ctx context.Context, organizationID *uuid.UUID) (Project, error) {
+	row := q.db.QueryRow(ctx, getProjectByBackingOrganizationID, organizationID)
+	var i Project
+	err := row.Scan(
+		&i.ID,
+		&i.OrganizationID,
+		&i.LogInWithPassword,
+		&i.LogInWithGoogle,
+		&i.LogInWithMicrosoft,
+		&i.GoogleOauthClientID,
+		&i.MicrosoftOauthClientID,
+		&i.GoogleOauthClientSecretCiphertext,
+		&i.MicrosoftOauthClientSecretCiphertext,
+		&i.DisplayName,
+		&i.CreateTime,
+		&i.UpdateTime,
+		&i.LoginsDisabled,
+		&i.LogInWithAuthenticatorApp,
+		&i.LogInWithPasskey,
+		&i.LogInWithEmail,
+		&i.LogInWithSaml,
+		&i.RedirectUri,
+		&i.AfterLoginRedirectUri,
+		&i.AfterSignupRedirectUri,
+		&i.VaultDomain,
+		&i.EmailSendFromDomain,
+	)
+	return i, err
+}
+
 const getProjectByID = `-- name: GetProjectByID :one
 SELECT
     id, organization_id, log_in_with_password, log_in_with_google, log_in_with_microsoft, google_oauth_client_id, microsoft_oauth_client_id, google_oauth_client_secret_ciphertext, microsoft_oauth_client_secret_ciphertext, display_name, create_time, update_time, logins_disabled, log_in_with_authenticator_app, log_in_with_passkey, log_in_with_email, log_in_with_saml, redirect_uri, after_login_redirect_uri, after_signup_redirect_uri, vault_domain, email_send_from_domain

--- a/sqlc/queries-intermediate.sql
+++ b/sqlc/queries-intermediate.sql
@@ -111,6 +111,14 @@ FROM
 WHERE
     id = $1;
 
+-- name: GetProjectByBackingOrganizationID :one
+SELECT
+    *
+FROM
+    projects
+WHERE
+    organization_id = $1;
+
 -- name: GetProjectTrustedDomains :many
 SELECT
     *


### PR DESCRIPTION
Previously, this would show "project_... Backing Organization":

![screenshot-2025-02-26-14-58-58](https://github.com/user-attachments/assets/53498d15-02ae-4a3e-8339-fb6a46328b2d)

Organizations keep their current naming convention:

![screenshot-2025-02-26-15-00-34](https://github.com/user-attachments/assets/3d854c1f-851f-4133-aebb-09e1419f543e)
