### PR TITLE
Have the config endpoint also be a valid jwks endpoint

### DIFF
--- a/internal/configapi/store/queries/queries-configapi.sql.go
+++ b/internal/configapi/store/queries/queries-configapi.sql.go
@@ -42,6 +42,8 @@ FROM
     publishable_keys
     JOIN projects ON publishable_keys.project_id = projects.id
     JOIN session_signing_keys ON projects.id = session_signing_keys.project_id
+WHERE
+    publishable_keys.id = $1
 `
 
 type GetPublishableKeySessionSigningPublicKeysRow struct {
@@ -49,8 +51,8 @@ type GetPublishableKeySessionSigningPublicKeysRow struct {
 	PublicKey []byte
 }
 
-func (q *Queries) GetPublishableKeySessionSigningPublicKeys(ctx context.Context) ([]GetPublishableKeySessionSigningPublicKeysRow, error) {
-	rows, err := q.db.Query(ctx, getPublishableKeySessionSigningPublicKeys)
+func (q *Queries) GetPublishableKeySessionSigningPublicKeys(ctx context.Context, id uuid.UUID) ([]GetPublishableKeySessionSigningPublicKeysRow, error) {
+	rows, err := q.db.Query(ctx, getPublishableKeySessionSigningPublicKeys, id)
 	if err != nil {
 		return nil, err
 	}

--- a/sqlc/queries-configapi.sql
+++ b/sqlc/queries-configapi.sql
@@ -15,5 +15,7 @@ SELECT
 FROM
     publishable_keys
     JOIN projects ON publishable_keys.project_id = projects.id
-    JOIN session_signing_keys ON projects.id = session_signing_keys.project_id;
+    JOIN session_signing_keys ON projects.id = session_signing_keys.project_id
+WHERE
+    publishable_keys.id = $1;
 


### PR DESCRIPTION
```console
$ curl -i https://config.tesseral.example.com/v1/config/publishable_key_78b34yplz6owh3c45jfpykeix
HTTP/1.1 200 OK
Server: nginx/1.27.3
Date: Sun, 02 Mar 2025 17:48:49 GMT
Content-Type: application/json
Content-Length: 290
Connection: keep-alive
Vary: Origin

{"projectId":"project_54vwf0clhh0caqe20eujxgpeq","vaultDomain":"auth.console.tesseral.example.com","keys":[{"crv":"P-256","kid":"session_signing_key_c384uca1sbus4xpki7j2kgaqt","kty":"EC","x":"qCByog0iFwVfDF-fkoPhKNW8JjNLGQJMk_atUGGbvoM","y":"vFZaL73AXgLcPxRS_yc9fsJTTiy-f-OVRD2IexKN17g"}]}
```