### PR TITLE
Fixes for signups in newly-created projects

### DIFF
--- a/.local/nginx/default.conf
+++ b/.local/nginx/default.conf
@@ -126,6 +126,60 @@ server {
 server {
   listen 443 ssl;
   listen [::]:443 ssl;
+  ssl_certificate /etc/nginx/conf.d/wildcard.tesseral.example.app.pem;
+  ssl_certificate_key /etc/nginx/conf.d/wildcard.tesseral.example.app-key.pem;
+  server_name *.tesseral.example.app;
+
+  location / {
+    proxy_http_version 1.1;
+    proxy_next_upstream error timeout http_500 http_502 http_503 http_504;
+    proxy_read_timeout 10s;
+    proxy_send_timeout 10s;
+    proxy_set_header Connection "upgrade";
+    proxy_set_header Host $host;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+
+    proxy_pass http://vault-ui:3002/;
+  }
+
+  location ~ ^/(api/.*) {
+    proxy_http_version 1.1;
+    proxy_next_upstream error timeout http_500 http_502 http_503 http_504;
+    proxy_read_timeout 10s;
+    proxy_send_timeout 10s;
+    proxy_set_header Connection "upgrade";
+    proxy_set_header Host $host;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header X-Tesseral-Host $http_host;
+
+    proxy_pass  http://api:3001/$1;
+  }
+
+  location ~ ^/(.well-known/.*) {
+    proxy_http_version 1.1;
+    proxy_next_upstream error timeout http_500 http_502 http_503 http_504;
+    proxy_read_timeout 10s;
+    proxy_send_timeout 10s;
+    proxy_set_header Connection "upgrade";
+    proxy_set_header Host $host;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+
+    proxy_pass  http://api:3001/$1;
+  }
+}
+
+server {
+  listen 443 ssl;
+  listen [::]:443 ssl;
   ssl_certificate /etc/nginx/conf.d/tesseralusercontent.example.com.pem;
   ssl_certificate_key /etc/nginx/conf.d/tesseralusercontent.example.com-key.pem;
   server_name tesseralusercontent.example.com;

--- a/bin/create-localhost-certs
+++ b/bin/create-localhost-certs
@@ -1,11 +1,12 @@
 #!/bin/bash
 
 create_cert() {
-  mkcert -cert-file .local/nginx/$1.pem -key-file .local/nginx/$1-key.pem $1
+  mkcert -cert-file .local/nginx/${1//\*/wildcard}.pem -key-file .local/nginx/${1//\*/wildcard}-key.pem $1
 }
 
 create_cert "api.tesseral.example.com"
 create_cert "config.tesseral.example.com"
 create_cert "console.tesseral.example.com"
 create_cert "auth.console.tesseral.example.com"
+create_cert "*.tesseral.example.app"
 create_cert "tesseralusercontent.example.com"

--- a/sqlc/queries-intermediate.sql
+++ b/sqlc/queries-intermediate.sql
@@ -564,8 +564,20 @@ RETURNING
     *;
 
 -- name: CreateProject :one
-INSERT INTO projects (id, organization_id, display_name, redirect_uri, vault_domain, email_send_from_domain, log_in_with_google, log_in_with_microsoft, log_in_with_password, log_in_with_saml)
-    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+INSERT INTO projects (id, organization_id, display_name, redirect_uri, vault_domain, email_send_from_domain, log_in_with_google, log_in_with_microsoft, log_in_with_password, log_in_with_saml, log_in_with_email)
+    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+RETURNING
+    *;
+
+-- name: CreateProjectUISettings :one
+INSERT INTO project_ui_settings (id, project_id)
+    VALUES (gen_random_uuid (), $1)
+RETURNING
+    *;
+
+-- name: CreateSessionSigningKey :one
+INSERT INTO session_signing_keys (id, project_id, public_key, private_key_cipher_text, create_time, expire_time)
+    VALUES ($1, $2, $3, $4, $5, $6)
 RETURNING
     *;
 

--- a/vault-ui/src/views/CreateOrganization.tsx
+++ b/vault-ui/src/views/CreateOrganization.tsx
@@ -71,15 +71,6 @@ const CreateOrganization: FC<CreateOrganizationProps> = ({ setView }) => {
         return;
       }
 
-      if (
-        !whoamiRes?.intermediateSession?.googleUserId &&
-        !whoamiRes?.intermediateSession?.microsoftUserId
-      ) {
-        setSubmitting(false);
-        setView(LoginViews.RegisterPassword);
-        return;
-      }
-
       intermediateExchangeAndRedirect();
     } catch (error) {
       setSubmitting(false);


### PR DESCRIPTION
This PR addresses issues I ran into when trying to sign up in new projects:

1. Have new projects have session signing keys and basic project UI settings
3. Fix some logic that required everyone to set a password
4. Have `*.tesseral.example.app` work locally (you still need to add entries to /etc/hosts manually, not sure I care to fix that)