### PR TITLE
Have configapi return trusted domains

### DIFF
--- a/.local/db/seed.sql
+++ b/.local/db/seed.sql
@@ -4,6 +4,11 @@ CREATE EXTENSION IF NOT EXISTS "pgcrypto";
 INSERT INTO projects (id, display_name, log_in_with_google, log_in_with_microsoft, log_in_with_email, log_in_with_password, log_in_with_saml, log_in_with_authenticator_app, log_in_with_passkey, vault_domain, email_send_from_domain, redirect_uri)
 	VALUES ('56bfa2b3-4f5a-4c68-8fc5-db3bf20731a2'::uuid, 'Tesseral Local Development', true, true, true, true, true, true, true, 'auth.console.tesseral.example.com', 'auth.console.tesseral.example.com', 'https://console.tesseral.example.com');
 
+insert into project_trusted_domains (id, project_id, domain)
+VALUES
+    (gen_random_uuid(), '56bfa2b3-4f5a-4c68-8fc5-db3bf20731a2', 'auth.console.tesseral.example.com'),
+    (gen_random_uuid(), '56bfa2b3-4f5a-4c68-8fc5-db3bf20731a2', 'console.tesseral.example.com');
+
 -- Create the Dogfood Project's backing organization
 INSERT INTO organizations (id, display_name, project_id, log_in_with_google, log_in_with_microsoft, log_in_with_email, log_in_with_password, log_in_with_saml, log_in_with_authenticator_app, log_in_with_passkey, scim_enabled)
   VALUES ('7a76decb-6d79-49ce-9449-34fcc53151df'::uuid, 'project_54vwf0clhh0caqe20eujxgpeq Backing Organization', '56bfa2b3-4f5a-4c68-8fc5-db3bf20731a2', true, false, true, true, true, true, true, true);

--- a/internal/configapi/store/publishable_keys.go
+++ b/internal/configapi/store/publishable_keys.go
@@ -14,9 +14,10 @@ import (
 )
 
 type GetPublishableKeyConfigurationResponse struct {
-	ProjectID   string           `json:"projectId"`
-	VaultDomain string           `json:"vaultDomain"`
-	Keys        []map[string]any `json:"keys"`
+	ProjectID      string           `json:"projectId"`
+	VaultDomain    string           `json:"vaultDomain"`
+	TrustedDomains []string         `json:"trustedDomains"`
+	Keys           []map[string]any `json:"keys"`
 }
 
 func (s *Store) GetPublishableKeyConfiguration(ctx context.Context, publishableKey string) (*GetPublishableKeyConfigurationResponse, error) {
@@ -31,6 +32,11 @@ func (s *Store) GetPublishableKeyConfiguration(ctx context.Context, publishableK
 			return nil, apierror.NewNotFoundError("publishable key not found", fmt.Errorf("get publishable key configuration: %w", err))
 		}
 		return nil, fmt.Errorf("get publishable key configuration: %w", err)
+	}
+
+	trustedDomains, err := s.q.GetPublishableKeyTrustedDomains(ctx, id)
+	if err != nil {
+		return nil, fmt.Errorf("get publishable key trusted domains: %w", err)
 	}
 
 	qSessionSigningKeys, err := s.q.GetPublishableKeySessionSigningPublicKeys(ctx, id)
@@ -55,8 +61,9 @@ func (s *Store) GetPublishableKeyConfiguration(ctx context.Context, publishableK
 	}
 
 	return &GetPublishableKeyConfigurationResponse{
-		ProjectID:   idformat.Project.Format(qConfig.ProjectID),
-		VaultDomain: qConfig.VaultDomain,
-		Keys:        keys,
+		ProjectID:      idformat.Project.Format(qConfig.ProjectID),
+		VaultDomain:    qConfig.VaultDomain,
+		TrustedDomains: trustedDomains,
+		Keys:           keys,
 	}, nil
 }

--- a/internal/configapi/store/queries/queries-configapi.sql.go
+++ b/internal/configapi/store/queries/queries-configapi.sql.go
@@ -70,3 +70,34 @@ func (q *Queries) GetPublishableKeySessionSigningPublicKeys(ctx context.Context,
 	}
 	return items, nil
 }
+
+const getPublishableKeyTrustedDomains = `-- name: GetPublishableKeyTrustedDomains :many
+SELECT
+    project_trusted_domains.domain
+FROM
+    publishable_keys
+    JOIN projects ON publishable_keys.project_id = projects.id
+    JOIN project_trusted_domains ON projects.id = project_trusted_domains.project_id
+WHERE
+    publishable_keys.id = $1
+`
+
+func (q *Queries) GetPublishableKeyTrustedDomains(ctx context.Context, id uuid.UUID) ([]string, error) {
+	rows, err := q.db.Query(ctx, getPublishableKeyTrustedDomains, id)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []string
+	for rows.Next() {
+		var domain string
+		if err := rows.Scan(&domain); err != nil {
+			return nil, err
+		}
+		items = append(items, domain)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}

--- a/sqlc/queries-configapi.sql
+++ b/sqlc/queries-configapi.sql
@@ -8,6 +8,16 @@ FROM
 WHERE
     publishable_keys.id = $1;
 
+-- name: GetPublishableKeyTrustedDomains :many
+SELECT
+    project_trusted_domains.domain
+FROM
+    publishable_keys
+    JOIN projects ON publishable_keys.project_id = projects.id
+    JOIN project_trusted_domains ON projects.id = project_trusted_domains.project_id
+WHERE
+    publishable_keys.id = $1;
+
 -- name: GetPublishableKeySessionSigningPublicKeys :many
 SELECT
     session_signing_keys.id,


### PR DESCRIPTION
```console
$ curl https://config.tesseral.example.com/v1/config/publishable_key_6j2fmidaok0j5ngmllr0ayyem -s | jq
{
  "projectId": "project_54vwf0clhh0caqe20eujxgpeq",
  "vaultDomain": "auth.console.tesseral.example.com",
  "trustedDomains": [
    "auth.console.tesseral.example.com",
    "console.tesseral.example.com"
  ],
  "keys": [
    {
      "crv": "P-256",
      "kid": "session_signing_key_4rrf7ergfgh38ehyuktk7mrcy",
      "kty": "EC",
      "x": "qCByog0iFwVfDF-fkoPhKNW8JjNLGQJMk_atUGGbvoM",
      "y": "vFZaL73AXgLcPxRS_yc9fsJTTiy-f-OVRD2IexKN17g"
    }
  ]
}
```