### PR TITLE
[OPEN-306] Make email verification links for dogfood go to console

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,4 @@
+API_CONSOLE_DOMAIN=console.tesseral.example.com
 API_AUTH_APPS_ROOT_DOMAIN=tesseral.example.app
 API_AUTHENTICATOR_APP_SECRETS_KMS_KEY_ID=186bf523-bc6a-479b-8ed1-e198298b98f2
 API_DB_DSN=postgres://postgres:password@0.0.0.0:5432/postgres

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -81,6 +81,7 @@ func main() {
 
 	config := struct {
 		RunAsLambda                         bool          `conf:"run_as_lambda,noredact"`
+		ConsoleDomain                       string        `conf:"console_domain,noredact"`
 		AuthAppsRootDomain                  string        `conf:"auth_apps_root_domain,noredact"`
 		TesseralDNSVaultCNAMEValue          string        `conf:"tesseral_dns_vault_cname_value,noredact"`
 		SESSPFMXRecordValue                 string        `conf:"ses_spf_mx_record_value,noredact"`
@@ -226,6 +227,7 @@ func main() {
 
 	// Register the intermediate service
 	intermediateStore := intermediatestore.New(intermediatestore.NewStoreParams{
+		ConsoleDomain:                         config.ConsoleDomain,
 		AuthAppsRootDomain:                    config.AuthAppsRootDomain,
 		DB:                                    db,
 		DogfoodProjectID:                      &uuidDogfoodProjectID,

--- a/internal/intermediate/store/email_verification_challenges.go
+++ b/internal/intermediate/store/email_verification_challenges.go
@@ -163,6 +163,11 @@ func (s *Store) sendEmailVerificationChallenge(ctx context.Context, toAddress st
 
 	subject := fmt.Sprintf("%s - Verify your email address", qProject.DisplayName)
 
+	vaultDomain := qProject.VaultDomain
+	if authn.ProjectID(ctx) == *s.dogfoodProjectID {
+		vaultDomain = s.consoleDomain
+	}
+
 	var body bytes.Buffer
 	if err := emailVerificationEmailBodyTmpl.Execute(&body, struct {
 		ProjectDisplayName    string
@@ -170,7 +175,7 @@ func (s *Store) sendEmailVerificationChallenge(ctx context.Context, toAddress st
 		EmailVerificationCode string
 	}{
 		ProjectDisplayName:    qProject.DisplayName,
-		EmailVerificationLink: fmt.Sprintf("https://%s/verify-email?code=%s", qProject.VaultDomain, secretToken),
+		EmailVerificationLink: fmt.Sprintf("https://%s/verify-email?code=%s", vaultDomain, secretToken),
 		EmailVerificationCode: secretToken,
 	}); err != nil {
 		return fmt.Errorf("execute email verification email body template: %w", err)

--- a/internal/intermediate/store/store.go
+++ b/internal/intermediate/store/store.go
@@ -18,6 +18,7 @@ import (
 )
 
 type Store struct {
+	consoleDomain                         string
 	authAppsRootDomain                    string
 	db                                    *pgxpool.Pool
 	dogfoodProjectID                      *uuid.UUID
@@ -37,6 +38,7 @@ type Store struct {
 }
 
 type NewStoreParams struct {
+	ConsoleDomain                         string
 	AuthAppsRootDomain                    string
 	DB                                    *pgxpool.Pool
 	DogfoodProjectID                      *uuid.UUID
@@ -55,6 +57,7 @@ type NewStoreParams struct {
 
 func New(p NewStoreParams) *Store {
 	store := &Store{
+		consoleDomain:      p.ConsoleDomain,
 		authAppsRootDomain: p.AuthAppsRootDomain,
 		db:                 p.DB,
 		dogfoodProjectID:   p.DogfoodProjectID,


### PR DESCRIPTION
This is a bit of a hack, but I think I'm OK with it because:

1. Its impact is limited to the dogfood, a place we already have a few special-cases for, and which we can relatively easily audit for such special-cases.
2. We're almost certainly going to want to be able to link to the console from the backend eventually.

Note how the email below links to console.tesseral.example.com, not vault.console.tesseral.example.com:

![screenshot-2025-04-06-14-03-59](https://github.com/user-attachments/assets/0385f631-bafd-4608-abf7-cba7f9f4ad1e)
