### PR TITLE
Make 500s opaque, log request/response pairs

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -41,12 +41,14 @@ import (
 	"github.com/tesseral-labs/tesseral/internal/googleoauth"
 	"github.com/tesseral-labs/tesseral/internal/hexkey"
 	"github.com/tesseral-labs/tesseral/internal/httplambda"
+	"github.com/tesseral-labs/tesseral/internal/httplog"
 	intermediateinterceptor "github.com/tesseral-labs/tesseral/internal/intermediate/authn/interceptor"
 	"github.com/tesseral-labs/tesseral/internal/intermediate/gen/tesseral/intermediate/v1/intermediatev1connect"
 	intermediateservice "github.com/tesseral-labs/tesseral/internal/intermediate/service"
 	intermediatestore "github.com/tesseral-labs/tesseral/internal/intermediate/store"
 	"github.com/tesseral-labs/tesseral/internal/loadenv"
 	"github.com/tesseral-labs/tesseral/internal/microsoftoauth"
+	"github.com/tesseral-labs/tesseral/internal/opaqueinternalerror"
 	"github.com/tesseral-labs/tesseral/internal/pagetoken"
 	samlinterceptor "github.com/tesseral-labs/tesseral/internal/saml/authn/interceptor"
 	samlservice "github.com/tesseral-labs/tesseral/internal/saml/service"
@@ -190,6 +192,8 @@ func main() {
 			Store: backendStore,
 		},
 		connect.WithInterceptors(
+			opaqueinternalerror.NewInterceptor(),
+			httplog.NewInterceptor(),
 			backendinterceptor.New(backendStore, config.DogfoodProjectID),
 		),
 	)
@@ -216,6 +220,8 @@ func main() {
 			Cookier:           &cookier,
 		},
 		connect.WithInterceptors(
+			opaqueinternalerror.NewInterceptor(),
+			httplog.NewInterceptor(),
 			frontendinterceptor.New(frontendStore, projectid.NewSniffer(config.AuthAppsRootDomain, commonStore), &cookier),
 		),
 	)
@@ -250,6 +256,8 @@ func main() {
 			Cookier:           &cookier,
 		},
 		connect.WithInterceptors(
+			opaqueinternalerror.NewInterceptor(),
+			httplog.NewInterceptor(),
 			intermediateinterceptor.New(intermediateStore, projectid.NewSniffer(config.AuthAppsRootDomain, commonStore), &cookier),
 		),
 	)

--- a/internal/httplog/httplog.go
+++ b/internal/httplog/httplog.go
@@ -1,0 +1,26 @@
+package httplog
+
+import (
+	"context"
+	"log/slog"
+
+	"connectrpc.com/connect"
+)
+
+func NewInterceptor() connect.Interceptor {
+	return connect.UnaryInterceptorFunc(func(next connect.UnaryFunc) connect.UnaryFunc {
+		return func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
+			slog.InfoContext(ctx, "http_request", "x_tesseral_host", req.Header().Get("X-Tesseral-Host"), "rpc", req.Spec().Procedure, "user_agent", req.Header().Get("User-Agent"))
+			res, err := next(ctx, req)
+
+			var errorCode string
+			if err != nil {
+				errorCode = connect.CodeOf(err).String()
+			}
+
+			// for convenience, log request details here too
+			slog.InfoContext(ctx, "error_code", errorCode, "http_response", "x_tesseral_host", req.Header().Get("X-Tesseral-Host"), "rpc", req.Spec().Procedure, "user_agent", req.Header().Get("User-Agent"))
+			return res, err
+		}
+	})
+}

--- a/internal/opaqueinternalerror/opaqueinternalerror.go
+++ b/internal/opaqueinternalerror/opaqueinternalerror.go
@@ -1,0 +1,30 @@
+package opaqueinternalerror
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+
+	"connectrpc.com/connect"
+	"github.com/getsentry/sentry-go"
+)
+
+func NewInterceptor() connect.Interceptor {
+	return connect.UnaryInterceptorFunc(func(next connect.UnaryFunc) connect.UnaryFunc {
+		return func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
+			res, err := next(ctx, req)
+			if err != nil {
+				var connectErr *connect.Error
+				if errors.As(err, &connectErr) {
+					return nil, connectErr
+				}
+
+				slog.ErrorContext(ctx, "internal_error", "err", err)
+				sentry.CaptureException(err)
+				return nil, connect.NewError(connect.CodeInternal, errors.New("internal server error"))
+			}
+
+			return res, nil
+		}
+	})
+}


### PR DESCRIPTION
500s look like this:

```
{"code":13, "message":"internal server error", "details":[]}
```

And we have logs like this now:

```
api-1       | {"time":"2025-04-08T00:14:17.968899423Z","level":"INFO","source":{"function":"main.main.NewInterceptor.func8.1","file":"/work/internal/httplog/httplog.go","line":13},"msg":"http_request","x_tesseral_host":"","rpc":"/tesseral.backend.v1.BackendService/ListUsers","user_agent":"curl/8.4.0","correlation_id":"da1f5ebf-5267-486b-8fd7-fe18cca10b1f"}
api-1       | {"time":"2025-04-08T00:14:17.972485257Z","level":"INFO","source":{"function":"main.main.NewInterceptor.func8.1","file":"/work/internal/httplog/httplog.go","line":22},"msg":"error_code","invalid_argument":"http_response","x_tesseral_host":"","rpc":"/tesseral.backend.v1.BackendService/ListUsers","user_agent":"curl/8.4.0","correlation_id":"da1f5ebf-5267-486b-8fd7-fe18cca10b1f"}
```

```
api-1       | {"time":"2025-04-08T00:14:32.041809305Z","level":"INFO","source":{"function":"main.main.NewInterceptor.func13.1","file":"/work/internal/httplog/httplog.go","line":22},"msg":"error_code","":"http_response","x_tesseral_host":"vault.console.tesseral.example.com","rpc":"/tesseral.intermediate.v1.IntermediateService/Whoami","user_agent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/134.0.0.0 Safari/537.36","correlation_id":"a7a90de0-3286-4d63-b6f6-2cbd72705717"}
api-1       | {"time":"2025-04-08T00:14:32.042338138Z","level":"INFO","source":{"function":"main.main.NewInterceptor.func13.1","file":"/work/internal/httplog/httplog.go","line":22},"msg":"error_code","":"http_response","x_tesseral_host":"vault.console.tesseral.example.com","rpc":"/tesseral.intermediate.v1.IntermediateService/GetSettings","user_agent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/134.0.0.0 Safari/537.36","correlation_id":"55a9cc7e-9de9-4780-8fe8-1ede5f46e4f7"}
```