### PR TITLE
[OPEN-349] Add titles to vault login pages

### DIFF
--- a/vault-ui/src/components/Title.tsx
+++ b/vault-ui/src/components/Title.tsx
@@ -5,7 +5,7 @@ export function Title({ title }: { title?: string }) {
   return (
     <Helmet>
       {/* TODO: Make this conditionally load an organization's configured Display Name */}
-      {title ? <title>{title} | Tesseral</title> : <title>Tesseral</title>}
+      {title && <title>{title}</title>}
     </Helmet>
   );
 }

--- a/vault-ui/src/pages/login/AuthenticateAnotherWayPage.tsx
+++ b/vault-ui/src/pages/login/AuthenticateAnotherWayPage.tsx
@@ -1,6 +1,7 @@
 import { useMutation, useQuery } from "@connectrpc/connect-query";
 import React from "react";
 
+import { Title } from "@/components/Title";
 import { GoogleIcon } from "@/components/login/GoogleIcon";
 import { LoginFlowCard } from "@/components/login/LoginFlowCard";
 import { MicrosoftIcon } from "@/components/login/MicrosoftIcon";
@@ -50,6 +51,7 @@ export function AuthenticateAnotherWayPage() {
 
   return (
     <LoginFlowCard>
+      <Title title="Authenticate another way" />
       <CardHeader>
         <CardTitle>Authenticate another way</CardTitle>
         <CardDescription>

--- a/vault-ui/src/pages/login/ChooseOrganizationPage.tsx
+++ b/vault-ui/src/pages/login/ChooseOrganizationPage.tsx
@@ -3,6 +3,7 @@ import React, { useEffect } from "react";
 import { useNavigate } from "react-router";
 import { Link } from "react-router-dom";
 
+import { Title } from "@/components/Title";
 import { LoginFlowCard } from "@/components/login/LoginFlowCard";
 import { Button } from "@/components/ui/button";
 import { CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -22,6 +23,7 @@ export function ChooseOrganizationPage() {
 
   return (
     <LoginFlowCard>
+      <Title title="Choose an organization" />
       <CardHeader>
         <CardTitle>Choose an organization</CardTitle>
       </CardHeader>

--- a/vault-ui/src/pages/login/CreateOrganizationPage.tsx
+++ b/vault-ui/src/pages/login/CreateOrganizationPage.tsx
@@ -5,6 +5,7 @@ import React, { useState } from "react";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
 
+import { Title } from "@/components/Title";
 import { LoginFlowCard } from "@/components/login/LoginFlowCard";
 import { Button } from "@/components/ui/button";
 import { CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -50,6 +51,7 @@ export function CreateOrganizationPage() {
 
   return (
     <LoginFlowCard>
+      <Title title="Create organization" />
       <CardHeader>
         <CardTitle>Create new organization</CardTitle>
       </CardHeader>

--- a/vault-ui/src/pages/login/ForgotPasswordPage.tsx
+++ b/vault-ui/src/pages/login/ForgotPasswordPage.tsx
@@ -6,6 +6,7 @@ import { useNavigate } from "react-router";
 import { toast } from "sonner";
 import { z } from "zod";
 
+import { Title } from "@/components/Title";
 import { LoginFlowCard } from "@/components/login/LoginFlowCard";
 import { Button } from "@/components/ui/button";
 import {
@@ -74,6 +75,7 @@ export function ForgotPasswordPage() {
 
   return (
     <LoginFlowCard>
+      <Title title="Forgot password" />
       <CardHeader>
         <CardTitle>Forgot password</CardTitle>
         <CardDescription>

--- a/vault-ui/src/pages/login/LoginPage.tsx
+++ b/vault-ui/src/pages/login/LoginPage.tsx
@@ -7,6 +7,7 @@ import { useNavigate } from "react-router";
 import { Link, useSearchParams } from "react-router-dom";
 import { z } from "zod";
 
+import { Title } from "@/components/Title";
 import { GoogleIcon } from "@/components/login/GoogleIcon";
 import { LoginFlowCard } from "@/components/login/LoginFlowCard";
 import { MicrosoftIcon } from "@/components/login/MicrosoftIcon";
@@ -176,6 +177,7 @@ function LoginPageContents() {
 
   return (
     <LoginFlowCard>
+      <Title title="Log in" />
       <CardHeader>
         <CardTitle>Log in to {settings.projectDisplayName}</CardTitle>
         <CardDescription>Please sign in to continue.</CardDescription>

--- a/vault-ui/src/pages/login/RegisterAuthenticatorAppPage.tsx
+++ b/vault-ui/src/pages/login/RegisterAuthenticatorAppPage.tsx
@@ -7,6 +7,7 @@ import { useForm } from "react-hook-form";
 import { toast } from "sonner";
 import { z } from "zod";
 
+import { Title } from "@/components/Title";
 import { LoginFlowCard } from "@/components/login/LoginFlowCard";
 import { Button } from "@/components/ui/button";
 import {
@@ -88,6 +89,7 @@ export function RegisterAuthenticatorAppPage() {
 
   return recoveryCodes ? (
     <LoginFlowCard>
+      <Title title="Register authenticator app" />
       <CardHeader>
         <CardTitle>Authenticator app recovery codes</CardTitle>
         <CardDescription>

--- a/vault-ui/src/pages/login/RegisterPasskeyPage.tsx
+++ b/vault-ui/src/pages/login/RegisterPasskeyPage.tsx
@@ -1,6 +1,7 @@
 import { useMutation } from "@connectrpc/connect-query";
 import React, { useCallback, useEffect } from "react";
 
+import { Title } from "@/components/Title";
 import { LoginFlowCard } from "@/components/login/LoginFlowCard";
 import { Button } from "@/components/ui/button";
 import {
@@ -68,6 +69,7 @@ export function RegisterPasskeyPage() {
 
   return (
     <LoginFlowCard>
+      <Title title="Register passkey" />
       <CardHeader>
         <CardTitle>Register a passkey</CardTitle>
         <CardDescription>

--- a/vault-ui/src/pages/login/RegisterPasswordPage.tsx
+++ b/vault-ui/src/pages/login/RegisterPasswordPage.tsx
@@ -6,6 +6,7 @@ import React, { useState } from "react";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
 
+import { Title } from "@/components/Title";
 import { LoginFlowCard } from "@/components/login/LoginFlowCard";
 import { Button } from "@/components/ui/button";
 import {
@@ -74,6 +75,7 @@ export function RegisterPasswordPage() {
 
   return (
     <LoginFlowCard>
+      <Title title="Register password" />
       <CardHeader>
         <CardTitle>Register password</CardTitle>
         <CardDescription>

--- a/vault-ui/src/pages/login/RegisterSecondaryFactorPage.tsx
+++ b/vault-ui/src/pages/login/RegisterSecondaryFactorPage.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Link } from "react-router-dom";
 
+import { Title } from "@/components/Title";
 import { LoginFlowCard } from "@/components/login/LoginFlowCard";
 import { Button } from "@/components/ui/button";
 import {
@@ -13,6 +14,7 @@ import {
 export function RegisterSecondaryFactorPage() {
   return (
     <LoginFlowCard>
+      <Title title="Set up secondary authentication factor" />
       <CardHeader>
         <CardTitle>Set up secondary authentication factor</CardTitle>
         <CardDescription>

--- a/vault-ui/src/pages/login/SignupPage.tsx
+++ b/vault-ui/src/pages/login/SignupPage.tsx
@@ -7,6 +7,7 @@ import { useNavigate } from "react-router";
 import { Link, useSearchParams } from "react-router-dom";
 import { z } from "zod";
 
+import { Title } from "@/components/Title";
 import { GoogleIcon } from "@/components/login/GoogleIcon";
 import { LoginFlowCard } from "@/components/login/LoginFlowCard";
 import { MicrosoftIcon } from "@/components/login/MicrosoftIcon";
@@ -176,6 +177,7 @@ function SignupPageContents() {
 
   return (
     <LoginFlowCard>
+      <Title title="Sign up" />
       <CardHeader>
         <CardTitle>Sign up for {settings.projectDisplayName}</CardTitle>
         <CardDescription>Please sign up to continue.</CardDescription>

--- a/vault-ui/src/pages/login/VerifyAuthenticatorAppPage.tsx
+++ b/vault-ui/src/pages/login/VerifyAuthenticatorAppPage.tsx
@@ -6,6 +6,7 @@ import { useForm } from "react-hook-form";
 import { Link } from "react-router-dom";
 import { z } from "zod";
 
+import { Title } from "@/components/Title";
 import { LoginFlowCard } from "@/components/login/LoginFlowCard";
 import { Button } from "@/components/ui/button";
 import {
@@ -58,6 +59,7 @@ export function VerifyAuthenticatorAppPage() {
 
   return (
     <LoginFlowCard>
+      <Title title="Verify authenticator app" />
       <CardHeader>
         <CardTitle>Verify authenticator app</CardTitle>
         <CardDescription>

--- a/vault-ui/src/pages/login/VerifyAuthenticatorAppRecoveryCodePage.tsx
+++ b/vault-ui/src/pages/login/VerifyAuthenticatorAppRecoveryCodePage.tsx
@@ -4,6 +4,7 @@ import React from "react";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
 
+import { Title } from "@/components/Title";
 import { LoginFlowCard } from "@/components/login/LoginFlowCard";
 import { Button } from "@/components/ui/button";
 import {
@@ -52,6 +53,7 @@ export function VerifyAuthenticatorAppRecoveryCodePage() {
 
   return (
     <LoginFlowCard>
+      <Title title="Verify authenticator app recovery code" />
       <CardHeader>
         <CardTitle>Verify authenticator app recovery code</CardTitle>
         <CardDescription>

--- a/vault-ui/src/pages/login/VerifyEmailPage.tsx
+++ b/vault-ui/src/pages/login/VerifyEmailPage.tsx
@@ -8,6 +8,7 @@ import { useSearchParams } from "react-router-dom";
 import { toast } from "sonner";
 import { z } from "zod";
 
+import { Title } from "@/components/Title";
 import { LoginFlowCard } from "@/components/login/LoginFlowCard";
 import {
   Accordion,
@@ -106,6 +107,7 @@ export function VerifyEmailPage() {
 
   return (
     <LoginFlowCard>
+      <Title title="Verify email" />
       <CardHeader>
         <CardTitle>Check your email</CardTitle>
         <CardDescription>

--- a/vault-ui/src/pages/login/VerifyPasskeyPage.tsx
+++ b/vault-ui/src/pages/login/VerifyPasskeyPage.tsx
@@ -1,6 +1,7 @@
 import { useMutation } from "@connectrpc/connect-query";
 import React, { useCallback, useEffect } from "react";
 
+import { Title } from "@/components/Title";
 import { LoginFlowCard } from "@/components/login/LoginFlowCard";
 import { Button } from "@/components/ui/button";
 import {
@@ -68,6 +69,7 @@ export function VerifyPasskeyPage() {
 
   return (
     <LoginFlowCard>
+      <Title title="Verify passkey" />
       <CardHeader>
         <CardTitle>Verify passkey</CardTitle>
         <CardDescription>

--- a/vault-ui/src/pages/login/VerifyPasswordPage.tsx
+++ b/vault-ui/src/pages/login/VerifyPasswordPage.tsx
@@ -6,6 +6,7 @@ import { useForm } from "react-hook-form";
 import { Link } from "react-router-dom";
 import { z } from "zod";
 
+import { Title } from "@/components/Title";
 import { LoginFlowCard } from "@/components/login/LoginFlowCard";
 import { Button } from "@/components/ui/button";
 import {
@@ -54,6 +55,7 @@ export function VerifyPasswordPage() {
 
   return (
     <LoginFlowCard>
+      <Title title="Verify your password" />
       <CardHeader>
         <CardTitle>Verify your password</CardTitle>
         <CardDescription>

--- a/vault-ui/src/pages/login/VerifySecondaryFactorPage.tsx
+++ b/vault-ui/src/pages/login/VerifySecondaryFactorPage.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Link } from "react-router-dom";
 
+import { Title } from "@/components/Title";
 import { LoginFlowCard } from "@/components/login/LoginFlowCard";
 import { Button } from "@/components/ui/button";
 import {
@@ -13,6 +14,7 @@ import {
 export function VerifySecondaryFactorPage() {
   return (
     <LoginFlowCard>
+      <Title title="Verify secondary authentication factor" />
       <CardHeader>
         <CardTitle>Verify secondary authentication factor</CardTitle>
         <CardDescription>


### PR DESCRIPTION
This PR adds `Title` components to the vault login pages. It also fixes the `Title` component to not include `Tesseral` in vault titles.