### PR TITLE
[OPEN-347] Add authenticate another way email support to console and vault

### DIFF
--- a/console/package-lock.json
+++ b/console/package-lock.json
@@ -47,7 +47,7 @@
         "react-colorful": "^5.6.1",
         "react-dom": "^18.3.1",
         "react-helmet": "^6.1.0",
-        "react-hook-form": "^7.54.2",
+        "react-hook-form": "^7.55.0",
         "react-router": "^6.28.0",
         "react-router-dom": "^6.28.0",
         "sonner": "^1.7.2",
@@ -6149,9 +6149,9 @@
       }
     },
     "node_modules/react-hook-form": {
-      "version": "7.54.2",
-      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.54.2.tgz",
-      "integrity": "sha512-eHpAUgUjWbZocoQYUHposymRb4ZP6d0uwUnooL2uOybA9/3tPUvoAKqEWK1WaSiTxxOfTpffNZP7QwlnM3/gEg==",
+      "version": "7.55.0",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.55.0.tgz",
+      "integrity": "sha512-XRnjsH3GVMQz1moZTW53MxfoWN7aDpUg/GpVNc4A3eXRVNdGXfbzJ4vM4aLQ8g6XCUh1nIbx70aaNCl7kxnjog==",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"

--- a/console/package.json
+++ b/console/package.json
@@ -58,7 +58,7 @@
     "react-colorful": "^5.6.1",
     "react-dom": "^18.3.1",
     "react-helmet": "^6.1.0",
-    "react-hook-form": "^7.54.2",
+    "react-hook-form": "^7.55.0",
     "react-router": "^6.28.0",
     "react-router-dom": "^6.28.0",
     "sonner": "^1.7.2",

--- a/console/src/pages/login/AuthenticateAnotherWayPage.tsx
+++ b/console/src/pages/login/AuthenticateAnotherWayPage.tsx
@@ -36,6 +36,10 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { useNavigate } from 'react-router';
 import { Input } from '@/components/ui/input';
 
+const schema = z.object({
+  email: z.string().email(),
+});
+
 export function AuthenticateAnotherWayPage() {
   const navigate = useNavigate();
 
@@ -86,10 +90,6 @@ export function AuthenticateAnotherWayPage() {
 
     navigate('/verify-email');
   }
-
-  const schema = z.object({
-    email: z.string().email(),
-  });
 
   const form = useForm<z.infer<typeof schema>>({
     resolver: zodResolver(schema),

--- a/console/src/pages/login/AuthenticateAnotherWayPage.tsx
+++ b/console/src/pages/login/AuthenticateAnotherWayPage.tsx
@@ -1,17 +1,17 @@
-import { useMutation, useQuery } from "@connectrpc/connect-query";
-import React, { useState } from "react";
-import { useForm } from "react-hook-form";
+import { useMutation, useQuery } from '@connectrpc/connect-query';
+import React, { useState } from 'react';
+import { useForm } from 'react-hook-form';
 
-import { GoogleIcon } from "@/components/login/GoogleIcon";
-import { LoginFlowCard } from "@/components/login/LoginFlowCard";
-import { MicrosoftIcon } from "@/components/login/MicrosoftIcon";
-import { Button } from "@/components/ui/button";
+import { GoogleIcon } from '@/components/login/GoogleIcon';
+import { LoginFlowCard } from '@/components/login/LoginFlowCard';
+import { MicrosoftIcon } from '@/components/login/MicrosoftIcon';
+import { Button } from '@/components/ui/button';
 import {
   CardContent,
   CardDescription,
   CardHeader,
   CardTitle,
-} from "@/components/ui/card";
+} from '@/components/ui/card';
 import {
   getGoogleOAuthRedirectURL,
   getMicrosoftOAuthRedirectURL,
@@ -19,9 +19,9 @@ import {
   listOrganizations,
   setEmailAsPrimaryLoginFactor,
   whoami,
-} from "@/gen/tesseral/intermediate/v1/intermediate-IntermediateService_connectquery";
-import { Title } from "@/components/Title";
-import TextDivider from "@/components/ui/text-divider";
+} from '@/gen/tesseral/intermediate/v1/intermediate-IntermediateService_connectquery';
+import { Title } from '@/components/Title';
+import TextDivider from '@/components/ui/text-divider';
 import {
   Form,
   FormControl,
@@ -29,12 +29,12 @@ import {
   FormItem,
   FormLabel,
   FormMessage,
-} from "@/components/ui/form";
-import { LoaderCircleIcon } from "lucide-react";
-import { z } from "zod";
-import { zodResolver } from "@hookform/resolvers/zod";
-import { useNavigate } from "react-router";
-import { Input } from "@/components/ui/input";
+} from '@/components/ui/form';
+import { LoaderCircleIcon } from 'lucide-react';
+import { z } from 'zod';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useNavigate } from 'react-router';
+import { Input } from '@/components/ui/input';
 
 export function AuthenticateAnotherWayPage() {
   const navigate = useNavigate();
@@ -84,7 +84,7 @@ export function AuthenticateAnotherWayPage() {
       email: values.email,
     });
 
-    navigate("/verify-email");
+    navigate('/verify-email');
   }
 
   const schema = z.object({
@@ -94,7 +94,7 @@ export function AuthenticateAnotherWayPage() {
   const form = useForm<z.infer<typeof schema>>({
     resolver: zodResolver(schema),
     defaultValues: {
-      email: "",
+      email: '',
     },
   });
 

--- a/console/src/pages/login/AuthenticateAnotherWayPage.tsx
+++ b/console/src/pages/login/AuthenticateAnotherWayPage.tsx
@@ -1,17 +1,17 @@
-import { useMutation, useQuery } from '@connectrpc/connect-query';
-import React, { useState } from 'react';
-import { useForm } from 'react-hook-form';
+import { useMutation, useQuery } from "@connectrpc/connect-query";
+import React, { useState } from "react";
+import { useForm } from "react-hook-form";
 
-import { GoogleIcon } from '@/components/login/GoogleIcon';
-import { LoginFlowCard } from '@/components/login/LoginFlowCard';
-import { MicrosoftIcon } from '@/components/login/MicrosoftIcon';
-import { Button } from '@/components/ui/button';
+import { GoogleIcon } from "@/components/login/GoogleIcon";
+import { LoginFlowCard } from "@/components/login/LoginFlowCard";
+import { MicrosoftIcon } from "@/components/login/MicrosoftIcon";
+import { Button } from "@/components/ui/button";
 import {
   CardContent,
   CardDescription,
   CardHeader,
   CardTitle,
-} from '@/components/ui/card';
+} from "@/components/ui/card";
 import {
   getGoogleOAuthRedirectURL,
   getMicrosoftOAuthRedirectURL,
@@ -19,9 +19,9 @@ import {
   listOrganizations,
   setEmailAsPrimaryLoginFactor,
   whoami,
-} from '@/gen/tesseral/intermediate/v1/intermediate-IntermediateService_connectquery';
-import { Title } from '@/components/Title';
-import TextDivider from '@/components/ui/text-divider';
+} from "@/gen/tesseral/intermediate/v1/intermediate-IntermediateService_connectquery";
+import { Title } from "@/components/Title";
+import TextDivider from "@/components/ui/text-divider";
 import {
   Form,
   FormControl,
@@ -29,12 +29,12 @@ import {
   FormItem,
   FormLabel,
   FormMessage,
-} from '@/components/ui/form';
-import { LoaderCircleIcon } from 'lucide-react';
-import { z } from 'zod';
-import { zodResolver } from '@hookform/resolvers/zod';
-import { useNavigate } from 'react-router';
-import { Input } from '@/components/ui/input';
+} from "@/components/ui/form";
+import { LoaderCircleIcon } from "lucide-react";
+import { z } from "zod";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useNavigate } from "react-router";
+import { Input } from "@/components/ui/input";
 
 export function AuthenticateAnotherWayPage() {
   const navigate = useNavigate();
@@ -84,7 +84,7 @@ export function AuthenticateAnotherWayPage() {
       email: values.email,
     });
 
-    navigate('/verify-email');
+    navigate("/verify-email");
   }
 
   const schema = z.object({
@@ -94,7 +94,7 @@ export function AuthenticateAnotherWayPage() {
   const form = useForm<z.infer<typeof schema>>({
     resolver: zodResolver(schema),
     defaultValues: {
-      email: '',
+      email: "",
     },
   });
 

--- a/console/src/pages/login/VerifyEmailPage.tsx
+++ b/console/src/pages/login/VerifyEmailPage.tsx
@@ -1,27 +1,27 @@
-import { useMutation, useQuery } from "@connectrpc/connect-query";
-import { zodResolver } from "@hookform/resolvers/zod";
-import { LoaderCircleIcon } from "lucide-react";
-import React, { useEffect, useState } from "react";
-import { useForm } from "react-hook-form";
-import { useNavigate } from "react-router";
-import { useSearchParams } from "react-router-dom";
-import { toast } from "sonner";
-import { z } from "zod";
+import { useMutation, useQuery } from '@connectrpc/connect-query';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { LoaderCircleIcon } from 'lucide-react';
+import React, { useEffect, useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { useNavigate } from 'react-router';
+import { useSearchParams } from 'react-router-dom';
+import { toast } from 'sonner';
+import { z } from 'zod';
 
-import { LoginFlowCard } from "@/components/login/LoginFlowCard";
+import { LoginFlowCard } from '@/components/login/LoginFlowCard';
 import {
   Accordion,
   AccordionContent,
   AccordionItem,
   AccordionTrigger,
-} from "@/components/ui/accordion";
-import { Button } from "@/components/ui/button";
+} from '@/components/ui/accordion';
+import { Button } from '@/components/ui/button';
 import {
   CardContent,
   CardDescription,
   CardHeader,
   CardTitle,
-} from "@/components/ui/card";
+} from '@/components/ui/card';
 import {
   Form,
   FormControl,
@@ -30,21 +30,24 @@ import {
   FormItem,
   FormLabel,
   FormMessage,
-} from "@/components/ui/form";
-import { Input } from "@/components/ui/input";
+} from '@/components/ui/form';
+import { Input } from '@/components/ui/input';
 import {
   issueEmailVerificationChallenge,
   verifyEmailChallenge,
   whoami,
-} from "@/gen/tesseral/intermediate/v1/intermediate-IntermediateService_connectquery";
+} from '@/gen/tesseral/intermediate/v1/intermediate-IntermediateService_connectquery';
+import { useRedirectNextLoginFlowPage } from '@/hooks/use-redirect-next-login-flow-page';
 
 const schema = z.object({
   emailVerificationChallengeCode: z
     .string()
-    .startsWith("email_verification_challenge_code_"),
+    .startsWith('email_verification_challenge_code_'),
 });
 
 export function VerifyEmailPage() {
+  const redirectNextLoginFlowPage = useRedirectNextLoginFlowPage();
+
   const { data: whoamiResponse } = useQuery(whoami);
 
   const issueEmailVerificationChallengeMutation = useMutation(
@@ -57,7 +60,7 @@ export function VerifyEmailPage() {
       email: whoamiResponse?.intermediateSession?.email,
     });
 
-    toast.success("New verification link sent");
+    toast.success('New verification link sent');
     setHasResent(true);
   }
 
@@ -71,7 +74,7 @@ export function VerifyEmailPage() {
   const form = useForm<z.infer<typeof schema>>({
     resolver: zodResolver(schema),
     defaultValues: {
-      emailVerificationChallengeCode: "",
+      emailVerificationChallengeCode: '',
     },
   });
 
@@ -87,19 +90,19 @@ export function VerifyEmailPage() {
       code: values.emailVerificationChallengeCode,
     });
 
-    navigate("/choose-organization");
+    redirectNextLoginFlowPage();
   }
 
   const [searchParams] = useSearchParams();
   useEffect(() => {
     (async () => {
-      const code = searchParams.get("code");
+      const code = searchParams.get('code');
       if (code) {
         await verifyEmailChallengeAsync({
           code,
         });
 
-        navigate("/choose-organization");
+        navigate('/choose-organization');
       }
     })();
   }, [searchParams, verifyEmailChallengeAsync, navigate]);
@@ -109,7 +112,7 @@ export function VerifyEmailPage() {
       <CardHeader>
         <CardTitle>Check your email</CardTitle>
         <CardDescription>
-          We've sent an email verification link to{" "}
+          We've sent an email verification link to{' '}
           <span className="font-medium">
             {whoamiResponse?.intermediateSession?.email}
           </span>
@@ -129,8 +132,8 @@ export function VerifyEmailPage() {
           onClick={handleResend}
         >
           {hasResent
-            ? "Email verification resent!"
-            : "Resend verification link"}
+            ? 'Email verification resent!'
+            : 'Resend verification link'}
         </Button>
 
         <div className="block relative w-full cursor-default my-2 mt-4">

--- a/console/src/pages/login/VerifyEmailPage.tsx
+++ b/console/src/pages/login/VerifyEmailPage.tsx
@@ -1,27 +1,27 @@
-import { useMutation, useQuery } from '@connectrpc/connect-query';
-import { zodResolver } from '@hookform/resolvers/zod';
-import { LoaderCircleIcon } from 'lucide-react';
-import React, { useEffect, useState } from 'react';
-import { useForm } from 'react-hook-form';
-import { useNavigate } from 'react-router';
-import { useSearchParams } from 'react-router-dom';
-import { toast } from 'sonner';
-import { z } from 'zod';
+import { useMutation, useQuery } from "@connectrpc/connect-query";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { LoaderCircleIcon } from "lucide-react";
+import React, { useEffect, useState } from "react";
+import { useForm } from "react-hook-form";
+import { useNavigate } from "react-router";
+import { useSearchParams } from "react-router-dom";
+import { toast } from "sonner";
+import { z } from "zod";
 
-import { LoginFlowCard } from '@/components/login/LoginFlowCard';
+import { LoginFlowCard } from "@/components/login/LoginFlowCard";
 import {
   Accordion,
   AccordionContent,
   AccordionItem,
   AccordionTrigger,
-} from '@/components/ui/accordion';
-import { Button } from '@/components/ui/button';
+} from "@/components/ui/accordion";
+import { Button } from "@/components/ui/button";
 import {
   CardContent,
   CardDescription,
   CardHeader,
   CardTitle,
-} from '@/components/ui/card';
+} from "@/components/ui/card";
 import {
   Form,
   FormControl,
@@ -30,19 +30,19 @@ import {
   FormItem,
   FormLabel,
   FormMessage,
-} from '@/components/ui/form';
-import { Input } from '@/components/ui/input';
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
 import {
   issueEmailVerificationChallenge,
   verifyEmailChallenge,
   whoami,
-} from '@/gen/tesseral/intermediate/v1/intermediate-IntermediateService_connectquery';
-import { useRedirectNextLoginFlowPage } from '@/hooks/use-redirect-next-login-flow-page';
+} from "@/gen/tesseral/intermediate/v1/intermediate-IntermediateService_connectquery";
+import { useRedirectNextLoginFlowPage } from "@/hooks/use-redirect-next-login-flow-page";
 
 const schema = z.object({
   emailVerificationChallengeCode: z
     .string()
-    .startsWith('email_verification_challenge_code_'),
+    .startsWith("email_verification_challenge_code_"),
 });
 
 export function VerifyEmailPage() {
@@ -60,7 +60,7 @@ export function VerifyEmailPage() {
       email: whoamiResponse?.intermediateSession?.email,
     });
 
-    toast.success('New verification link sent');
+    toast.success("New verification link sent");
     setHasResent(true);
   }
 
@@ -74,7 +74,7 @@ export function VerifyEmailPage() {
   const form = useForm<z.infer<typeof schema>>({
     resolver: zodResolver(schema),
     defaultValues: {
-      emailVerificationChallengeCode: '',
+      emailVerificationChallengeCode: "",
     },
   });
 
@@ -96,13 +96,13 @@ export function VerifyEmailPage() {
   const [searchParams] = useSearchParams();
   useEffect(() => {
     (async () => {
-      const code = searchParams.get('code');
+      const code = searchParams.get("code");
       if (code) {
         await verifyEmailChallengeAsync({
           code,
         });
 
-        navigate('/choose-organization');
+        navigate("/choose-organization");
       }
     })();
   }, [searchParams, verifyEmailChallengeAsync, navigate]);
@@ -112,7 +112,7 @@ export function VerifyEmailPage() {
       <CardHeader>
         <CardTitle>Check your email</CardTitle>
         <CardDescription>
-          We've sent an email verification link to{' '}
+          We've sent an email verification link to{" "}
           <span className="font-medium">
             {whoamiResponse?.intermediateSession?.email}
           </span>
@@ -132,8 +132,8 @@ export function VerifyEmailPage() {
           onClick={handleResend}
         >
           {hasResent
-            ? 'Email verification resent!'
-            : 'Resend verification link'}
+            ? "Email verification resent!"
+            : "Resend verification link"}
         </Button>
 
         <div className="block relative w-full cursor-default my-2 mt-4">

--- a/vault-ui/src/pages/login/AuthenticateAnotherWayPage.tsx
+++ b/vault-ui/src/pages/login/AuthenticateAnotherWayPage.tsx
@@ -28,7 +28,6 @@ import {
 import { Input } from "@/components/ui/input";
 import TextDivider from "@/components/ui/text-divider";
 import {
-  createIntermediateSession,
   getGoogleOAuthRedirectURL,
   getMicrosoftOAuthRedirectURL,
   issueEmailVerificationChallenge,

--- a/vault-ui/src/pages/login/AuthenticateAnotherWayPage.tsx
+++ b/vault-ui/src/pages/login/AuthenticateAnotherWayPage.tsx
@@ -36,6 +36,10 @@ import {
   whoami,
 } from "@/gen/tesseral/intermediate/v1/intermediate-IntermediateService_connectquery";
 
+const schema = z.object({
+  email: z.string().email(),
+});
+
 export function AuthenticateAnotherWayPage() {
   const navigate = useNavigate();
 
@@ -85,10 +89,6 @@ export function AuthenticateAnotherWayPage() {
 
     navigate("/verify-email");
   }
-
-  const schema = z.object({
-    email: z.string().email(),
-  });
 
   const form = useForm<z.infer<typeof schema>>({
     resolver: zodResolver(schema),

--- a/vault-ui/src/pages/login/AuthenticateAnotherWayPage.tsx
+++ b/vault-ui/src/pages/login/AuthenticateAnotherWayPage.tsx
@@ -1,5 +1,10 @@
 import { useMutation, useQuery } from "@connectrpc/connect-query";
-import React from "react";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { LoaderCircleIcon } from "lucide-react";
+import React, { useState } from "react";
+import { useForm } from "react-hook-form";
+import { useNavigate } from "react-router";
+import { z } from "zod";
 
 import { Title } from "@/components/Title";
 import { GoogleIcon } from "@/components/login/GoogleIcon";
@@ -13,13 +18,30 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import TextDivider from "@/components/ui/text-divider";
+import {
+  createIntermediateSession,
   getGoogleOAuthRedirectURL,
   getMicrosoftOAuthRedirectURL,
+  issueEmailVerificationChallenge,
   listOrganizations,
+  setEmailAsPrimaryLoginFactor,
   whoami,
 } from "@/gen/tesseral/intermediate/v1/intermediate-IntermediateService_connectquery";
 
 export function AuthenticateAnotherWayPage() {
+  const navigate = useNavigate();
+
+  const [submitting, setSubmitting] = useState(false);
+
   const { data: whoamiResponse } = useQuery(whoami);
   const { data: listOrganizationsResponse } = useQuery(listOrganizations);
 
@@ -29,6 +51,12 @@ export function AuthenticateAnotherWayPage() {
 
   const { mutateAsync: getGoogleOAuthRedirectURLAsync } = useMutation(
     getGoogleOAuthRedirectURL,
+  );
+  const setEmailAsPrimaryLoginFactorMutation = useMutation(
+    setEmailAsPrimaryLoginFactor,
+  );
+  const issueEmailVerificationChallengeMutation = useMutation(
+    issueEmailVerificationChallenge,
   );
 
   async function handleLogInWithGoogle() {
@@ -48,6 +76,27 @@ export function AuthenticateAnotherWayPage() {
     });
     window.location.href = url;
   }
+
+  async function handleSubmit(values: z.infer<typeof schema>) {
+    setSubmitting(true);
+    await setEmailAsPrimaryLoginFactorMutation.mutateAsync({});
+    await issueEmailVerificationChallengeMutation.mutateAsync({
+      email: values.email,
+    });
+
+    navigate("/verify-email");
+  }
+
+  const schema = z.object({
+    email: z.string().email(),
+  });
+
+  const form = useForm<z.infer<typeof schema>>({
+    resolver: zodResolver(schema),
+    defaultValues: {
+      email: "",
+    },
+  });
 
   return (
     <LoginFlowCard>
@@ -80,6 +129,46 @@ export function AuthenticateAnotherWayPage() {
               <MicrosoftIcon />
               Log in with Microsoft
             </Button>
+          )}
+
+          {organization?.logInWithEmail && (
+            <>
+              {(organization?.logInWithGoogle ||
+                organization?.logInWithMicrosoft) && (
+                <TextDivider>or</TextDivider>
+              )}
+
+              <Form {...form}>
+                <form onSubmit={form.handleSubmit(handleSubmit)}>
+                  <FormField
+                    control={form.control}
+                    name="email"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>Email</FormLabel>
+                        <FormControl>
+                          <Input
+                            placeholder="john.doe@example.com"
+                            {...field}
+                          />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                  <Button
+                    type="submit"
+                    className="mt-4 w-full"
+                    disabled={submitting}
+                  >
+                    {submitting && (
+                      <LoaderCircleIcon className="h-4 w-4 animate-spin" />
+                    )}
+                    Log in
+                  </Button>
+                </form>
+              </Form>
+            </>
           )}
         </div>
       </CardContent>

--- a/vault-ui/src/pages/login/VerifyEmailPage.tsx
+++ b/vault-ui/src/pages/login/VerifyEmailPage.tsx
@@ -38,6 +38,7 @@ import {
   verifyEmailChallenge,
   whoami,
 } from "@/gen/tesseral/intermediate/v1/intermediate-IntermediateService_connectquery";
+import { useRedirectNextLoginFlowPage } from "@/hooks/use-redirect-next-login-flow-page";
 
 const schema = z.object({
   emailVerificationChallengeCode: z
@@ -47,6 +48,8 @@ const schema = z.object({
 
 export function VerifyEmailPage() {
   const { data: whoamiResponse } = useQuery(whoami);
+
+  const redirectNextLoginFlowPage = useRedirectNextLoginFlowPage();
 
   const issueEmailVerificationChallengeMutation = useMutation(
     issueEmailVerificationChallenge,
@@ -88,7 +91,7 @@ export function VerifyEmailPage() {
       code: values.emailVerificationChallengeCode,
     });
 
-    navigate("/choose-organization");
+    redirectNextLoginFlowPage();
   }
 
   const [searchParams] = useSearchParams();


### PR DESCRIPTION
This PR adds support for log in with email in the "authenticate another way" flow.

To prevent invalid redirects after email verification, it updates the redirect logic to use the `useRedirectNextLoginFlowPage` function instead of a hard-coded link to `/choose-organization`.

Email login tested locally in vault and console for both initial email login and "authenticate another way" email login.

I also updated the `react-hook-form` package to fix the gross typing issues they had in their previous version.