### PR TITLE
[OPEN-345] Implement daily quotas on transactional emails per project

### DIFF
--- a/cmd/openauthctl/migrations/000069_email_quotas.up.sql
+++ b/cmd/openauthctl/migrations/000069_email_quotas.up.sql
@@ -1,0 +1,11 @@
+alter table projects
+    add column email_quota_daily int;
+
+create table project_email_quota_daily_usage
+(
+    project_id  uuid not null primary key references projects (id),
+    date        date not null,
+    quota_usage int  not null,
+
+    unique (project_id, date)
+);

--- a/internal/backend/store/queries/models.go
+++ b/internal/backend/store/queries/models.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
 )
 
 type AuthMethod string
@@ -266,6 +267,13 @@ type Project struct {
 	VaultDomain                          string
 	EmailSendFromDomain                  string
 	CookieDomain                         string
+	EmailQuotaDaily                      *int32
+}
+
+type ProjectEmailQuotaDailyUsage struct {
+	ProjectID  uuid.UUID
+	Date       pgtype.Date
+	QuotaUsage int32
 }
 
 type ProjectTrustedDomain struct {

--- a/internal/backend/store/queries/queries-backend.sql.go
+++ b/internal/backend/store/queries/queries-backend.sql.go
@@ -971,7 +971,7 @@ func (q *Queries) GetPasskey(ctx context.Context, arg GetPasskeyParams) (Passkey
 
 const getProjectByID = `-- name: GetProjectByID :one
 SELECT
-    id, organization_id, log_in_with_password, log_in_with_google, log_in_with_microsoft, google_oauth_client_id, microsoft_oauth_client_id, google_oauth_client_secret_ciphertext, microsoft_oauth_client_secret_ciphertext, display_name, create_time, update_time, logins_disabled, log_in_with_authenticator_app, log_in_with_passkey, log_in_with_email, log_in_with_saml, redirect_uri, after_login_redirect_uri, after_signup_redirect_uri, vault_domain, email_send_from_domain, cookie_domain
+    id, organization_id, log_in_with_password, log_in_with_google, log_in_with_microsoft, google_oauth_client_id, microsoft_oauth_client_id, google_oauth_client_secret_ciphertext, microsoft_oauth_client_secret_ciphertext, display_name, create_time, update_time, logins_disabled, log_in_with_authenticator_app, log_in_with_passkey, log_in_with_email, log_in_with_saml, redirect_uri, after_login_redirect_uri, after_signup_redirect_uri, vault_domain, email_send_from_domain, cookie_domain, email_quota_daily
 FROM
     projects
 WHERE
@@ -1005,6 +1005,7 @@ func (q *Queries) GetProjectByID(ctx context.Context, id uuid.UUID) (Project, er
 		&i.VaultDomain,
 		&i.EmailSendFromDomain,
 		&i.CookieDomain,
+		&i.EmailQuotaDaily,
 	)
 	return i, err
 }
@@ -1544,7 +1545,7 @@ func (q *Queries) ListPasskeys(ctx context.Context, arg ListPasskeysParams) ([]P
 
 const listProjects = `-- name: ListProjects :many
 SELECT
-    id, organization_id, log_in_with_password, log_in_with_google, log_in_with_microsoft, google_oauth_client_id, microsoft_oauth_client_id, google_oauth_client_secret_ciphertext, microsoft_oauth_client_secret_ciphertext, display_name, create_time, update_time, logins_disabled, log_in_with_authenticator_app, log_in_with_passkey, log_in_with_email, log_in_with_saml, redirect_uri, after_login_redirect_uri, after_signup_redirect_uri, vault_domain, email_send_from_domain, cookie_domain
+    id, organization_id, log_in_with_password, log_in_with_google, log_in_with_microsoft, google_oauth_client_id, microsoft_oauth_client_id, google_oauth_client_secret_ciphertext, microsoft_oauth_client_secret_ciphertext, display_name, create_time, update_time, logins_disabled, log_in_with_authenticator_app, log_in_with_passkey, log_in_with_email, log_in_with_saml, redirect_uri, after_login_redirect_uri, after_signup_redirect_uri, vault_domain, email_send_from_domain, cookie_domain, email_quota_daily
 FROM
     projects
 ORDER BY
@@ -1585,6 +1586,7 @@ func (q *Queries) ListProjects(ctx context.Context, limit int32) ([]Project, err
 			&i.VaultDomain,
 			&i.EmailSendFromDomain,
 			&i.CookieDomain,
+			&i.EmailQuotaDaily,
 		); err != nil {
 			return nil, err
 		}
@@ -2162,7 +2164,7 @@ SET
 WHERE
     id = $1
 RETURNING
-    id, organization_id, log_in_with_password, log_in_with_google, log_in_with_microsoft, google_oauth_client_id, microsoft_oauth_client_id, google_oauth_client_secret_ciphertext, microsoft_oauth_client_secret_ciphertext, display_name, create_time, update_time, logins_disabled, log_in_with_authenticator_app, log_in_with_passkey, log_in_with_email, log_in_with_saml, redirect_uri, after_login_redirect_uri, after_signup_redirect_uri, vault_domain, email_send_from_domain, cookie_domain
+    id, organization_id, log_in_with_password, log_in_with_google, log_in_with_microsoft, google_oauth_client_id, microsoft_oauth_client_id, google_oauth_client_secret_ciphertext, microsoft_oauth_client_secret_ciphertext, display_name, create_time, update_time, logins_disabled, log_in_with_authenticator_app, log_in_with_passkey, log_in_with_email, log_in_with_saml, redirect_uri, after_login_redirect_uri, after_signup_redirect_uri, vault_domain, email_send_from_domain, cookie_domain, email_quota_daily
 `
 
 type UpdateProjectParams struct {
@@ -2230,6 +2232,7 @@ func (q *Queries) UpdateProject(ctx context.Context, arg UpdateProjectParams) (P
 		&i.VaultDomain,
 		&i.EmailSendFromDomain,
 		&i.CookieDomain,
+		&i.EmailQuotaDaily,
 	)
 	return i, err
 }
@@ -2242,7 +2245,7 @@ SET
 WHERE
     id = $1
 RETURNING
-    id, organization_id, log_in_with_password, log_in_with_google, log_in_with_microsoft, google_oauth_client_id, microsoft_oauth_client_id, google_oauth_client_secret_ciphertext, microsoft_oauth_client_secret_ciphertext, display_name, create_time, update_time, logins_disabled, log_in_with_authenticator_app, log_in_with_passkey, log_in_with_email, log_in_with_saml, redirect_uri, after_login_redirect_uri, after_signup_redirect_uri, vault_domain, email_send_from_domain, cookie_domain
+    id, organization_id, log_in_with_password, log_in_with_google, log_in_with_microsoft, google_oauth_client_id, microsoft_oauth_client_id, google_oauth_client_secret_ciphertext, microsoft_oauth_client_secret_ciphertext, display_name, create_time, update_time, logins_disabled, log_in_with_authenticator_app, log_in_with_passkey, log_in_with_email, log_in_with_saml, redirect_uri, after_login_redirect_uri, after_signup_redirect_uri, vault_domain, email_send_from_domain, cookie_domain, email_quota_daily
 `
 
 type UpdateProjectEmailSendFromDomainParams struct {
@@ -2277,6 +2280,7 @@ func (q *Queries) UpdateProjectEmailSendFromDomain(ctx context.Context, arg Upda
 		&i.VaultDomain,
 		&i.EmailSendFromDomain,
 		&i.CookieDomain,
+		&i.EmailQuotaDaily,
 	)
 	return i, err
 }
@@ -2289,7 +2293,7 @@ SET
 WHERE
     id = $1
 RETURNING
-    id, organization_id, log_in_with_password, log_in_with_google, log_in_with_microsoft, google_oauth_client_id, microsoft_oauth_client_id, google_oauth_client_secret_ciphertext, microsoft_oauth_client_secret_ciphertext, display_name, create_time, update_time, logins_disabled, log_in_with_authenticator_app, log_in_with_passkey, log_in_with_email, log_in_with_saml, redirect_uri, after_login_redirect_uri, after_signup_redirect_uri, vault_domain, email_send_from_domain, cookie_domain
+    id, organization_id, log_in_with_password, log_in_with_google, log_in_with_microsoft, google_oauth_client_id, microsoft_oauth_client_id, google_oauth_client_secret_ciphertext, microsoft_oauth_client_secret_ciphertext, display_name, create_time, update_time, logins_disabled, log_in_with_authenticator_app, log_in_with_passkey, log_in_with_email, log_in_with_saml, redirect_uri, after_login_redirect_uri, after_signup_redirect_uri, vault_domain, email_send_from_domain, cookie_domain, email_quota_daily
 `
 
 type UpdateProjectOrganizationIDParams struct {
@@ -2324,6 +2328,7 @@ func (q *Queries) UpdateProjectOrganizationID(ctx context.Context, arg UpdatePro
 		&i.VaultDomain,
 		&i.EmailSendFromDomain,
 		&i.CookieDomain,
+		&i.EmailQuotaDaily,
 	)
 	return i, err
 }
@@ -2385,7 +2390,7 @@ SET
 WHERE
     id = $1
 RETURNING
-    id, organization_id, log_in_with_password, log_in_with_google, log_in_with_microsoft, google_oauth_client_id, microsoft_oauth_client_id, google_oauth_client_secret_ciphertext, microsoft_oauth_client_secret_ciphertext, display_name, create_time, update_time, logins_disabled, log_in_with_authenticator_app, log_in_with_passkey, log_in_with_email, log_in_with_saml, redirect_uri, after_login_redirect_uri, after_signup_redirect_uri, vault_domain, email_send_from_domain, cookie_domain
+    id, organization_id, log_in_with_password, log_in_with_google, log_in_with_microsoft, google_oauth_client_id, microsoft_oauth_client_id, google_oauth_client_secret_ciphertext, microsoft_oauth_client_secret_ciphertext, display_name, create_time, update_time, logins_disabled, log_in_with_authenticator_app, log_in_with_passkey, log_in_with_email, log_in_with_saml, redirect_uri, after_login_redirect_uri, after_signup_redirect_uri, vault_domain, email_send_from_domain, cookie_domain, email_quota_daily
 `
 
 type UpdateProjectVaultDomainParams struct {
@@ -2421,6 +2426,7 @@ func (q *Queries) UpdateProjectVaultDomain(ctx context.Context, arg UpdateProjec
 		&i.VaultDomain,
 		&i.EmailSendFromDomain,
 		&i.CookieDomain,
+		&i.EmailQuotaDaily,
 	)
 	return i, err
 }

--- a/internal/common/store/queries/models.go
+++ b/internal/common/store/queries/models.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
 )
 
 type AuthMethod string
@@ -266,6 +267,13 @@ type Project struct {
 	VaultDomain                          string
 	EmailSendFromDomain                  string
 	CookieDomain                         string
+	EmailQuotaDaily                      *int32
+}
+
+type ProjectEmailQuotaDailyUsage struct {
+	ProjectID  uuid.UUID
+	Date       pgtype.Date
+	QuotaUsage int32
 }
 
 type ProjectTrustedDomain struct {

--- a/internal/configapi/store/queries/models.go
+++ b/internal/configapi/store/queries/models.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
 )
 
 type AuthMethod string
@@ -266,6 +267,13 @@ type Project struct {
 	VaultDomain                          string
 	EmailSendFromDomain                  string
 	CookieDomain                         string
+	EmailQuotaDaily                      *int32
+}
+
+type ProjectEmailQuotaDailyUsage struct {
+	ProjectID  uuid.UUID
+	Date       pgtype.Date
+	QuotaUsage int32
 }
 
 type ProjectTrustedDomain struct {

--- a/internal/frontend/store/queries/models.go
+++ b/internal/frontend/store/queries/models.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
 )
 
 type AuthMethod string
@@ -266,6 +267,13 @@ type Project struct {
 	VaultDomain                          string
 	EmailSendFromDomain                  string
 	CookieDomain                         string
+	EmailQuotaDaily                      *int32
+}
+
+type ProjectEmailQuotaDailyUsage struct {
+	ProjectID  uuid.UUID
+	Date       pgtype.Date
+	QuotaUsage int32
 }
 
 type ProjectTrustedDomain struct {

--- a/internal/frontend/store/queries/queries-frontend.sql.go
+++ b/internal/frontend/store/queries/queries-frontend.sql.go
@@ -492,7 +492,7 @@ func (q *Queries) GetOrganizationMicrosoftTenantIDs(ctx context.Context, organiz
 
 const getProjectByBackingOrganizationID = `-- name: GetProjectByBackingOrganizationID :one
 SELECT
-    id, organization_id, log_in_with_password, log_in_with_google, log_in_with_microsoft, google_oauth_client_id, microsoft_oauth_client_id, google_oauth_client_secret_ciphertext, microsoft_oauth_client_secret_ciphertext, display_name, create_time, update_time, logins_disabled, log_in_with_authenticator_app, log_in_with_passkey, log_in_with_email, log_in_with_saml, redirect_uri, after_login_redirect_uri, after_signup_redirect_uri, vault_domain, email_send_from_domain, cookie_domain
+    id, organization_id, log_in_with_password, log_in_with_google, log_in_with_microsoft, google_oauth_client_id, microsoft_oauth_client_id, google_oauth_client_secret_ciphertext, microsoft_oauth_client_secret_ciphertext, display_name, create_time, update_time, logins_disabled, log_in_with_authenticator_app, log_in_with_passkey, log_in_with_email, log_in_with_saml, redirect_uri, after_login_redirect_uri, after_signup_redirect_uri, vault_domain, email_send_from_domain, cookie_domain, email_quota_daily
 FROM
     projects
 WHERE
@@ -526,13 +526,14 @@ func (q *Queries) GetProjectByBackingOrganizationID(ctx context.Context, organiz
 		&i.VaultDomain,
 		&i.EmailSendFromDomain,
 		&i.CookieDomain,
+		&i.EmailQuotaDaily,
 	)
 	return i, err
 }
 
 const getProjectByID = `-- name: GetProjectByID :one
 SELECT
-    id, organization_id, log_in_with_password, log_in_with_google, log_in_with_microsoft, google_oauth_client_id, microsoft_oauth_client_id, google_oauth_client_secret_ciphertext, microsoft_oauth_client_secret_ciphertext, display_name, create_time, update_time, logins_disabled, log_in_with_authenticator_app, log_in_with_passkey, log_in_with_email, log_in_with_saml, redirect_uri, after_login_redirect_uri, after_signup_redirect_uri, vault_domain, email_send_from_domain, cookie_domain
+    id, organization_id, log_in_with_password, log_in_with_google, log_in_with_microsoft, google_oauth_client_id, microsoft_oauth_client_id, google_oauth_client_secret_ciphertext, microsoft_oauth_client_secret_ciphertext, display_name, create_time, update_time, logins_disabled, log_in_with_authenticator_app, log_in_with_passkey, log_in_with_email, log_in_with_saml, redirect_uri, after_login_redirect_uri, after_signup_redirect_uri, vault_domain, email_send_from_domain, cookie_domain, email_quota_daily
 FROM
     projects
 WHERE
@@ -566,6 +567,7 @@ func (q *Queries) GetProjectByID(ctx context.Context, id uuid.UUID) (Project, er
 		&i.VaultDomain,
 		&i.EmailSendFromDomain,
 		&i.CookieDomain,
+		&i.EmailQuotaDaily,
 	)
 	return i, err
 }

--- a/internal/intermediate/store/email_verification_challenges.go
+++ b/internal/intermediate/store/email_verification_challenges.go
@@ -21,6 +21,10 @@ import (
 	"github.com/tesseral-labs/tesseral/internal/store/idformat"
 )
 
+// defaultEmailQuotaDaily is the default number of emails a project may send per
+// day.
+var defaultEmailQuotaDaily int32 = 1000
+
 func (s *Store) IssueEmailVerificationChallenge(ctx context.Context, req *intermediatev1.IssueEmailVerificationChallengeRequest) (*intermediatev1.IssueEmailVerificationChallengeResponse, error) {
 	_, q, commit, rollback, err := s.tx(ctx)
 	if err != nil {
@@ -75,7 +79,7 @@ func (s *Store) IssueEmailVerificationChallenge(ctx context.Context, req *interm
 		return nil, fmt.Errorf("increment project email daily quota usage: %w", err)
 	}
 
-	emailQuotaDaily := int32(100)
+	emailQuotaDaily := defaultEmailQuotaDaily
 	if qProject.EmailQuotaDaily != nil {
 		emailQuotaDaily = *qProject.EmailQuotaDaily
 	}

--- a/internal/intermediate/store/passwords.go
+++ b/internal/intermediate/store/passwords.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"html/template"
+	"log/slog"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -283,6 +284,11 @@ func (s *Store) IssuePasswordResetCode(ctx context.Context, req *intermediatev1.
 	}
 	defer rollback()
 
+	qProject, err := q.GetProjectByID(ctx, authn.ProjectID(ctx))
+	if err != nil {
+		return nil, fmt.Errorf("get project by id: %w", err)
+	}
+
 	qIntermediateSession, err := q.GetIntermediateSessionByID(ctx, authn.IntermediateSessionID(ctx))
 	if err != nil {
 		return nil, fmt.Errorf("get intermediate session by id: %w", err)
@@ -308,6 +314,23 @@ func (s *Store) IssuePasswordResetCode(ctx context.Context, req *intermediatev1.
 		PasswordResetCodeSha256: passwordResetCodeSHA256[:],
 	}); err != nil {
 		return nil, fmt.Errorf("update intermediate session password reset code sha256: %w", err)
+	}
+
+	qEmailDailyQuotaUsage, err := q.IncrementProjectEmailDailyQuotaUsage(ctx, authn.ProjectID(ctx))
+	if err != nil {
+		return nil, fmt.Errorf("increment project email daily quota usage: %w", err)
+	}
+
+	emailQuotaDaily := int32(100)
+	if qProject.EmailQuotaDaily != nil {
+		emailQuotaDaily = *qProject.EmailQuotaDaily
+	}
+
+	slog.InfoContext(ctx, "email_daily_quota_usage", "usage", qEmailDailyQuotaUsage.QuotaUsage, "quota", qProject.EmailQuotaDaily)
+
+	if qEmailDailyQuotaUsage.QuotaUsage > emailQuotaDaily {
+		slog.InfoContext(ctx, "email_daily_quota_exceeded")
+		return nil, apierror.NewFailedPreconditionError("email daily quota exceeded", fmt.Errorf("email daily quota exceeded"))
 	}
 
 	if err := commit(); err != nil {

--- a/internal/intermediate/store/passwords.go
+++ b/internal/intermediate/store/passwords.go
@@ -321,7 +321,7 @@ func (s *Store) IssuePasswordResetCode(ctx context.Context, req *intermediatev1.
 		return nil, fmt.Errorf("increment project email daily quota usage: %w", err)
 	}
 
-	emailQuotaDaily := int32(100)
+	emailQuotaDaily := defaultEmailQuotaDaily
 	if qProject.EmailQuotaDaily != nil {
 		emailQuotaDaily = *qProject.EmailQuotaDaily
 	}

--- a/internal/intermediate/store/queries/models.go
+++ b/internal/intermediate/store/queries/models.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
 )
 
 type AuthMethod string
@@ -266,6 +267,13 @@ type Project struct {
 	VaultDomain                          string
 	EmailSendFromDomain                  string
 	CookieDomain                         string
+	EmailQuotaDaily                      *int32
+}
+
+type ProjectEmailQuotaDailyUsage struct {
+	ProjectID  uuid.UUID
+	Date       pgtype.Date
+	QuotaUsage int32
 }
 
 type ProjectTrustedDomain struct {

--- a/internal/intermediate/store/queries/queries-intermediate.sql.go
+++ b/internal/intermediate/store/queries/queries-intermediate.sql.go
@@ -1248,7 +1248,7 @@ func (q *Queries) GetUserPasskeyCredentialIDs(ctx context.Context, userID uuid.U
 const incrementProjectEmailDailyQuotaUsage = `-- name: IncrementProjectEmailDailyQuotaUsage :one
 INSERT INTO project_email_quota_daily_usage (project_id, date, quota_usage)
     VALUES ($1, CURRENT_DATE, 1)
-ON CONFLICT
+ON CONFLICT (project_id, date)
     DO UPDATE SET
         quota_usage = project_email_quota_daily_usage.quota_usage + 1
     RETURNING

--- a/internal/intermediate/store/queries/queries-intermediate.sql.go
+++ b/internal/intermediate/store/queries/queries-intermediate.sql.go
@@ -253,7 +253,7 @@ const createProject = `-- name: CreateProject :one
 INSERT INTO projects (id, organization_id, display_name, redirect_uri, vault_domain, email_send_from_domain, log_in_with_google, log_in_with_microsoft, log_in_with_password, log_in_with_saml, log_in_with_email, cookie_domain)
     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
 RETURNING
-    id, organization_id, log_in_with_password, log_in_with_google, log_in_with_microsoft, google_oauth_client_id, microsoft_oauth_client_id, google_oauth_client_secret_ciphertext, microsoft_oauth_client_secret_ciphertext, display_name, create_time, update_time, logins_disabled, log_in_with_authenticator_app, log_in_with_passkey, log_in_with_email, log_in_with_saml, redirect_uri, after_login_redirect_uri, after_signup_redirect_uri, vault_domain, email_send_from_domain, cookie_domain
+    id, organization_id, log_in_with_password, log_in_with_google, log_in_with_microsoft, google_oauth_client_id, microsoft_oauth_client_id, google_oauth_client_secret_ciphertext, microsoft_oauth_client_secret_ciphertext, display_name, create_time, update_time, logins_disabled, log_in_with_authenticator_app, log_in_with_passkey, log_in_with_email, log_in_with_saml, redirect_uri, after_login_redirect_uri, after_signup_redirect_uri, vault_domain, email_send_from_domain, cookie_domain, email_quota_daily
 `
 
 type CreateProjectParams struct {
@@ -311,6 +311,7 @@ func (q *Queries) CreateProject(ctx context.Context, arg CreateProjectParams) (P
 		&i.VaultDomain,
 		&i.EmailSendFromDomain,
 		&i.CookieDomain,
+		&i.EmailQuotaDaily,
 	)
 	return i, err
 }
@@ -942,7 +943,7 @@ func (q *Queries) GetPasskeyByCredentialID(ctx context.Context, arg GetPasskeyBy
 
 const getProjectByBackingOrganizationID = `-- name: GetProjectByBackingOrganizationID :one
 SELECT
-    id, organization_id, log_in_with_password, log_in_with_google, log_in_with_microsoft, google_oauth_client_id, microsoft_oauth_client_id, google_oauth_client_secret_ciphertext, microsoft_oauth_client_secret_ciphertext, display_name, create_time, update_time, logins_disabled, log_in_with_authenticator_app, log_in_with_passkey, log_in_with_email, log_in_with_saml, redirect_uri, after_login_redirect_uri, after_signup_redirect_uri, vault_domain, email_send_from_domain, cookie_domain
+    id, organization_id, log_in_with_password, log_in_with_google, log_in_with_microsoft, google_oauth_client_id, microsoft_oauth_client_id, google_oauth_client_secret_ciphertext, microsoft_oauth_client_secret_ciphertext, display_name, create_time, update_time, logins_disabled, log_in_with_authenticator_app, log_in_with_passkey, log_in_with_email, log_in_with_saml, redirect_uri, after_login_redirect_uri, after_signup_redirect_uri, vault_domain, email_send_from_domain, cookie_domain, email_quota_daily
 FROM
     projects
 WHERE
@@ -976,13 +977,14 @@ func (q *Queries) GetProjectByBackingOrganizationID(ctx context.Context, organiz
 		&i.VaultDomain,
 		&i.EmailSendFromDomain,
 		&i.CookieDomain,
+		&i.EmailQuotaDaily,
 	)
 	return i, err
 }
 
 const getProjectByID = `-- name: GetProjectByID :one
 SELECT
-    id, organization_id, log_in_with_password, log_in_with_google, log_in_with_microsoft, google_oauth_client_id, microsoft_oauth_client_id, google_oauth_client_secret_ciphertext, microsoft_oauth_client_secret_ciphertext, display_name, create_time, update_time, logins_disabled, log_in_with_authenticator_app, log_in_with_passkey, log_in_with_email, log_in_with_saml, redirect_uri, after_login_redirect_uri, after_signup_redirect_uri, vault_domain, email_send_from_domain, cookie_domain
+    id, organization_id, log_in_with_password, log_in_with_google, log_in_with_microsoft, google_oauth_client_id, microsoft_oauth_client_id, google_oauth_client_secret_ciphertext, microsoft_oauth_client_secret_ciphertext, display_name, create_time, update_time, logins_disabled, log_in_with_authenticator_app, log_in_with_passkey, log_in_with_email, log_in_with_saml, redirect_uri, after_login_redirect_uri, after_signup_redirect_uri, vault_domain, email_send_from_domain, cookie_domain, email_quota_daily
 FROM
     projects
 WHERE
@@ -1016,6 +1018,7 @@ func (q *Queries) GetProjectByID(ctx context.Context, id uuid.UUID) (Project, er
 		&i.VaultDomain,
 		&i.EmailSendFromDomain,
 		&i.CookieDomain,
+		&i.EmailQuotaDaily,
 	)
 	return i, err
 }
@@ -1240,6 +1243,23 @@ func (q *Queries) GetUserPasskeyCredentialIDs(ctx context.Context, userID uuid.U
 		return nil, err
 	}
 	return items, nil
+}
+
+const incrementProjectEmailDailyQuotaUsage = `-- name: IncrementProjectEmailDailyQuotaUsage :one
+INSERT INTO project_email_quota_daily_usage (project_id, date, quota_usage)
+    VALUES ($1, CURRENT_DATE, 1)
+ON CONFLICT
+    DO UPDATE SET
+        quota_usage = project_email_quota_daily_usage.quota_usage + 1
+    RETURNING
+        project_id, date, quota_usage
+`
+
+func (q *Queries) IncrementProjectEmailDailyQuotaUsage(ctx context.Context, projectID uuid.UUID) (ProjectEmailQuotaDailyUsage, error) {
+	row := q.db.QueryRow(ctx, incrementProjectEmailDailyQuotaUsage, projectID)
+	var i ProjectEmailQuotaDailyUsage
+	err := row.Scan(&i.ProjectID, &i.Date, &i.QuotaUsage)
+	return i, err
 }
 
 const invalidateSession = `-- name: InvalidateSession :exec

--- a/internal/saml/store/queries/models.go
+++ b/internal/saml/store/queries/models.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
 )
 
 type AuthMethod string
@@ -266,6 +267,13 @@ type Project struct {
 	VaultDomain                          string
 	EmailSendFromDomain                  string
 	CookieDomain                         string
+	EmailQuotaDaily                      *int32
+}
+
+type ProjectEmailQuotaDailyUsage struct {
+	ProjectID  uuid.UUID
+	Date       pgtype.Date
+	QuotaUsage int32
 }
 
 type ProjectTrustedDomain struct {

--- a/internal/saml/store/queries/queries-saml.sql.go
+++ b/internal/saml/store/queries/queries-saml.sql.go
@@ -121,7 +121,7 @@ func (q *Queries) GetOrganizationDomains(ctx context.Context, organizationID uui
 
 const getProject = `-- name: GetProject :one
 SELECT
-    id, organization_id, log_in_with_password, log_in_with_google, log_in_with_microsoft, google_oauth_client_id, microsoft_oauth_client_id, google_oauth_client_secret_ciphertext, microsoft_oauth_client_secret_ciphertext, display_name, create_time, update_time, logins_disabled, log_in_with_authenticator_app, log_in_with_passkey, log_in_with_email, log_in_with_saml, redirect_uri, after_login_redirect_uri, after_signup_redirect_uri, vault_domain, email_send_from_domain, cookie_domain
+    id, organization_id, log_in_with_password, log_in_with_google, log_in_with_microsoft, google_oauth_client_id, microsoft_oauth_client_id, google_oauth_client_secret_ciphertext, microsoft_oauth_client_secret_ciphertext, display_name, create_time, update_time, logins_disabled, log_in_with_authenticator_app, log_in_with_passkey, log_in_with_email, log_in_with_saml, redirect_uri, after_login_redirect_uri, after_signup_redirect_uri, vault_domain, email_send_from_domain, cookie_domain, email_quota_daily
 FROM
     projects
 WHERE
@@ -155,6 +155,7 @@ func (q *Queries) GetProject(ctx context.Context, id uuid.UUID) (Project, error)
 		&i.VaultDomain,
 		&i.EmailSendFromDomain,
 		&i.CookieDomain,
+		&i.EmailQuotaDaily,
 	)
 	return i, err
 }

--- a/internal/scim/store/queries/models.go
+++ b/internal/scim/store/queries/models.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
 )
 
 type AuthMethod string
@@ -266,6 +267,13 @@ type Project struct {
 	VaultDomain                          string
 	EmailSendFromDomain                  string
 	CookieDomain                         string
+	EmailQuotaDaily                      *int32
+}
+
+type ProjectEmailQuotaDailyUsage struct {
+	ProjectID  uuid.UUID
+	Date       pgtype.Date
+	QuotaUsage int32
 }
 
 type ProjectTrustedDomain struct {

--- a/internal/store/queries/models.go
+++ b/internal/store/queries/models.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
 )
 
 type AuthMethod string
@@ -266,6 +267,13 @@ type Project struct {
 	VaultDomain                          string
 	EmailSendFromDomain                  string
 	CookieDomain                         string
+	EmailQuotaDaily                      *int32
+}
+
+type ProjectEmailQuotaDailyUsage struct {
+	ProjectID  uuid.UUID
+	Date       pgtype.Date
+	QuotaUsage int32
 }
 
 type ProjectTrustedDomain struct {

--- a/internal/store/queries/queries.sql.go
+++ b/internal/store/queries/queries.sql.go
@@ -30,7 +30,7 @@ const createDogfoodProject = `-- name: CreateDogfoodProject :one
 INSERT INTO projects (id, display_name, redirect_uri, log_in_with_google, log_in_with_microsoft, log_in_with_email, log_in_with_password, vault_domain, email_send_from_domain, cookie_domain)
     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
 RETURNING
-    id, organization_id, log_in_with_password, log_in_with_google, log_in_with_microsoft, google_oauth_client_id, microsoft_oauth_client_id, google_oauth_client_secret_ciphertext, microsoft_oauth_client_secret_ciphertext, display_name, create_time, update_time, logins_disabled, log_in_with_authenticator_app, log_in_with_passkey, log_in_with_email, log_in_with_saml, redirect_uri, after_login_redirect_uri, after_signup_redirect_uri, vault_domain, email_send_from_domain, cookie_domain
+    id, organization_id, log_in_with_password, log_in_with_google, log_in_with_microsoft, google_oauth_client_id, microsoft_oauth_client_id, google_oauth_client_secret_ciphertext, microsoft_oauth_client_secret_ciphertext, display_name, create_time, update_time, logins_disabled, log_in_with_authenticator_app, log_in_with_passkey, log_in_with_email, log_in_with_saml, redirect_uri, after_login_redirect_uri, after_signup_redirect_uri, vault_domain, email_send_from_domain, cookie_domain, email_quota_daily
 `
 
 type CreateDogfoodProjectParams struct {
@@ -84,6 +84,7 @@ func (q *Queries) CreateDogfoodProject(ctx context.Context, arg CreateDogfoodPro
 		&i.VaultDomain,
 		&i.EmailSendFromDomain,
 		&i.CookieDomain,
+		&i.EmailQuotaDaily,
 	)
 	return i, err
 }
@@ -349,7 +350,7 @@ func (q *Queries) GetOrganizationByProjectIDAndID(ctx context.Context, arg GetOr
 
 const getProjectByID = `-- name: GetProjectByID :one
 SELECT
-    id, organization_id, log_in_with_password, log_in_with_google, log_in_with_microsoft, google_oauth_client_id, microsoft_oauth_client_id, google_oauth_client_secret_ciphertext, microsoft_oauth_client_secret_ciphertext, display_name, create_time, update_time, logins_disabled, log_in_with_authenticator_app, log_in_with_passkey, log_in_with_email, log_in_with_saml, redirect_uri, after_login_redirect_uri, after_signup_redirect_uri, vault_domain, email_send_from_domain, cookie_domain
+    id, organization_id, log_in_with_password, log_in_with_google, log_in_with_microsoft, google_oauth_client_id, microsoft_oauth_client_id, google_oauth_client_secret_ciphertext, microsoft_oauth_client_secret_ciphertext, display_name, create_time, update_time, logins_disabled, log_in_with_authenticator_app, log_in_with_passkey, log_in_with_email, log_in_with_saml, redirect_uri, after_login_redirect_uri, after_signup_redirect_uri, vault_domain, email_send_from_domain, cookie_domain, email_quota_daily
 FROM
     projects
 WHERE
@@ -383,6 +384,7 @@ func (q *Queries) GetProjectByID(ctx context.Context, id uuid.UUID) (Project, er
 		&i.VaultDomain,
 		&i.EmailSendFromDomain,
 		&i.CookieDomain,
+		&i.EmailQuotaDaily,
 	)
 	return i, err
 }
@@ -499,7 +501,7 @@ SET
 WHERE
     id = $1
 RETURNING
-    id, organization_id, log_in_with_password, log_in_with_google, log_in_with_microsoft, google_oauth_client_id, microsoft_oauth_client_id, google_oauth_client_secret_ciphertext, microsoft_oauth_client_secret_ciphertext, display_name, create_time, update_time, logins_disabled, log_in_with_authenticator_app, log_in_with_passkey, log_in_with_email, log_in_with_saml, redirect_uri, after_login_redirect_uri, after_signup_redirect_uri, vault_domain, email_send_from_domain, cookie_domain
+    id, organization_id, log_in_with_password, log_in_with_google, log_in_with_microsoft, google_oauth_client_id, microsoft_oauth_client_id, google_oauth_client_secret_ciphertext, microsoft_oauth_client_secret_ciphertext, display_name, create_time, update_time, logins_disabled, log_in_with_authenticator_app, log_in_with_passkey, log_in_with_email, log_in_with_saml, redirect_uri, after_login_redirect_uri, after_signup_redirect_uri, vault_domain, email_send_from_domain, cookie_domain, email_quota_daily
 `
 
 type UpdateProjectOrganizationIDParams struct {
@@ -578,6 +580,7 @@ func (q *Queries) UpdateProjectOrganizationID(ctx context.Context, arg UpdatePro
 		&i.VaultDomain,
 		&i.EmailSendFromDomain,
 		&i.CookieDomain,
+		&i.EmailQuotaDaily,
 	)
 	return i, err
 }

--- a/internal/wellknown/store/queries/models.go
+++ b/internal/wellknown/store/queries/models.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
 )
 
 type AuthMethod string
@@ -266,6 +267,13 @@ type Project struct {
 	VaultDomain                          string
 	EmailSendFromDomain                  string
 	CookieDomain                         string
+	EmailQuotaDaily                      *int32
+}
+
+type ProjectEmailQuotaDailyUsage struct {
+	ProjectID  uuid.UUID
+	Date       pgtype.Date
+	QuotaUsage int32
 }
 
 type ProjectTrustedDomain struct {

--- a/sqlc/queries-intermediate.sql
+++ b/sqlc/queries-intermediate.sql
@@ -665,7 +665,7 @@ WHERE
 -- name: IncrementProjectEmailDailyQuotaUsage :one
 INSERT INTO project_email_quota_daily_usage (project_id, date, quota_usage)
     VALUES ($1, CURRENT_DATE, 1)
-ON CONFLICT
+ON CONFLICT (project_id, date)
     DO UPDATE SET
         quota_usage = project_email_quota_daily_usage.quota_usage + 1
     RETURNING

--- a/sqlc/queries-intermediate.sql
+++ b/sqlc/queries-intermediate.sql
@@ -662,3 +662,12 @@ SET
 WHERE
     id = $1;
 
+-- name: IncrementProjectEmailDailyQuotaUsage :one
+INSERT INTO project_email_quota_daily_usage (project_id, date, quota_usage)
+    VALUES ($1, CURRENT_DATE, 1)
+ON CONFLICT
+    DO UPDATE SET
+        quota_usage = project_email_quota_daily_usage.quota_usage + 1
+    RETURNING
+        *;
+


### PR DESCRIPTION
These quotas can be modified per-project, with a global default.

As a demo of this limit being implemented in staging, if a project is in the state where their limit is 100 per day, and they've already consumed that limit:

```
tesseraldb=> select * from project_email_quota_daily_usage ;
              project_id              |    date    | quota_usage 
--------------------------------------+------------+-------------
 be647431-a850-47e7-942c-c6041101233a | 2025-04-11 |         100
(1 row)
```

Then attempting to "Resend verification link" results in:

```
{
    "code": "failed_precondition",
    "message": "failed_precondition",
    "details": [
        {
            "type": "tesseral.common.v1.ErrorDetail",
            "value": "ChplbWFpbCBkYWlseSBxdW90YSBleGNlZWRlZA",
            "debug": {
                "description": "email daily quota exceeded"
            }
        }
    ]
}
```