### PR TITLE
[OPEN-346] Create Users and Organizations from the console

### DIFF
--- a/console/src/pages/organizations/ListOrganizationsPage.tsx
+++ b/console/src/pages/organizations/ListOrganizationsPage.tsx
@@ -100,7 +100,7 @@ export const ListOrganizationsPage = () => {
       </PageDescription>
 
       <Card className="mt-8 overflow-hidden">
-        <CardHeader className="flex flex-row items-center space-x-4 justify-between">
+        <CardHeader className="flex-row justify-between items-center space-x-4">
           <div className="flex flex-col space-y-1 5">
             <CardTitle>Organizations list</CardTitle>
             <CardDescription>
@@ -167,11 +167,15 @@ export const ListOrganizationsPage = () => {
   );
 };
 
+const schema = z.object({
+  displayName: z.string(),
+});
+
 const CreateOrganizationButton: FC = () => {
   const navigate = useNavigate();
 
-  const form = useForm<z.infer<typeof organizationSchema>>({
-    resolver: zodResolver(organizationSchema),
+  const form = useForm<z.infer<typeof schema>>({
+    resolver: zodResolver(schema),
     defaultValues: {
       displayName: '',
     },
@@ -181,7 +185,7 @@ const CreateOrganizationButton: FC = () => {
 
   const [open, setOpen] = useState(false);
 
-  const handleSubmit = async (values: z.infer<typeof organizationSchema>) => {
+  const handleSubmit = async (values: z.infer<typeof schema>) => {
     const createOrganizationResponse =
       await createOrganizationMutation.mutateAsync({
         organization: {
@@ -240,7 +244,3 @@ const CreateOrganizationButton: FC = () => {
     </AlertDialog>
   );
 };
-
-const organizationSchema = z.object({
-  displayName: z.string(),
-});

--- a/console/src/pages/organizations/ListOrganizationsPage.tsx
+++ b/console/src/pages/organizations/ListOrganizationsPage.tsx
@@ -104,8 +104,8 @@ export const ListOrganizationsPage = () => {
           <div className="flex flex-col space-y-1 5">
             <CardTitle>Organizations list</CardTitle>
             <CardDescription>
-              This is a list of all organizations in your project. You can
-              create and edit these organizations manually.
+              This is a list of all Organizations in your project. You can
+              create and edit these Organizations manually.
             </CardDescription>
           </div>
           <CreateOrganizationButton />
@@ -207,7 +207,7 @@ const CreateOrganizationButton: FC = () => {
         <AlertDialogHeader>
           <AlertDialogTitle>Create Organization</AlertDialogTitle>
           <AlertDialogDescription>
-            Create a new organization.
+            Create a new Organization.
           </AlertDialogDescription>
         </AlertDialogHeader>
 
@@ -224,7 +224,7 @@ const CreateOrganizationButton: FC = () => {
                   <FormLabel>Display Name</FormLabel>
                   <Input placeholder="ACME Corp" {...field} />
                   <FormDescription>
-                    The display name of the organization. This will be displayed
+                    The display name of the Organization. This will be displayed
                     to users during the login process.
                   </FormDescription>
                 </FormItem>

--- a/console/src/pages/organizations/ListOrganizationsPage.tsx
+++ b/console/src/pages/organizations/ListOrganizationsPage.tsx
@@ -14,7 +14,7 @@ import {
 } from '@/components/ui/table';
 import { DateTime } from 'luxon';
 import { timestampDate } from '@bufbuild/protobuf/wkt';
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import {
   Card,
   CardContent,
@@ -108,11 +108,7 @@ export const ListOrganizationsPage = () => {
               create and edit these organizations manually.
             </CardDescription>
           </div>
-          <CreateOrganizationButton
-            onSubmit={async () => {
-              await refetch();
-            }}
-          />
+          <CreateOrganizationButton />
         </CardHeader>
         <CardContent className="-m-6 mt-0">
           <Table>
@@ -171,13 +167,9 @@ export const ListOrganizationsPage = () => {
   );
 };
 
-interface CreateOrganizationButtonProps {
-  onSubmit: () => Promise<void>;
-}
+const CreateOrganizationButton: FC = () => {
+  const navigate = useNavigate();
 
-const CreateOrganizationButton: FC<CreateOrganizationButtonProps> = ({
-  onSubmit,
-}) => {
   const form = useForm<z.infer<typeof organizationSchema>>({
     resolver: zodResolver(organizationSchema),
     defaultValues: {
@@ -190,15 +182,17 @@ const CreateOrganizationButton: FC<CreateOrganizationButtonProps> = ({
   const [open, setOpen] = useState(false);
 
   const handleSubmit = async (values: z.infer<typeof organizationSchema>) => {
-    await createOrganizationMutation.mutateAsync({
-      organization: {
-        ...values,
-      },
-    });
+    const createOrganizationResponse =
+      await createOrganizationMutation.mutateAsync({
+        organization: {
+          ...values,
+        },
+      });
     toast.success('Organization created successfully');
-    await onSubmit();
 
     setOpen(false);
+
+    navigate(`/organizations/${createOrganizationResponse.organization?.id}`);
   };
 
   return (

--- a/console/src/pages/organizations/ListOrganizationsPage.tsx
+++ b/console/src/pages/organizations/ListOrganizationsPage.tsx
@@ -218,7 +218,10 @@ const CreateOrganizationButton: FC<CreateOrganizationButtonProps> = ({
         </AlertDialogHeader>
 
         <Form {...form}>
-          <form onSubmit={form.handleSubmit(handleSubmit)}>
+          <form
+            className="space-y-4"
+            onSubmit={form.handleSubmit(handleSubmit)}
+          >
             <FormField
               control={form.control}
               name="displayName"

--- a/console/src/pages/organizations/OrganizationUsersTab.tsx
+++ b/console/src/pages/organizations/OrganizationUsersTab.tsx
@@ -1,6 +1,10 @@
-import React from 'react';
-import { useQuery } from '@connectrpc/connect-query';
-import { listUsers } from '@/gen/tesseral/backend/v1/backend-BackendService_connectquery';
+import React, { FC, useState } from 'react';
+import { useMutation, useQuery } from '@connectrpc/connect-query';
+import {
+  createUser,
+  getOrganization,
+  listUsers,
+} from '@/gen/tesseral/backend/v1/backend-BackendService_connectquery';
 import {
   Card,
   CardContent,
@@ -21,20 +25,52 @@ import { DateTime } from 'luxon';
 import { timestampDate } from '@bufbuild/protobuf/wkt';
 import { useParams } from 'react-router';
 import { Badge } from '@/components/ui/badge';
+import {
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from '@/components/ui/alert-dialog';
+import { Button } from '@/components/ui/button';
+import {
+  Form,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+} from '@/components/ui/form';
+import { z } from 'zod';
+import { useForm } from 'react-hook-form';
+import { AlertDialogCancel } from '@radix-ui/react-alert-dialog';
+import { Input } from '@/components/ui/input';
+import { Switch } from '@/components/ui/switch';
+import { CirclePlus } from 'lucide-react';
+import { toast } from 'sonner';
+import { User } from '@/gen/tesseral/backend/v1/models_pb';
 
 export const OrganizationUsersTab = () => {
   const { organizationId } = useParams();
-  const { data: listUsersResponse } = useQuery(listUsers, {
+  const { data: listUsersResponse, refetch } = useQuery(listUsers, {
     organizationId,
   });
 
   return (
     <Card>
-      <CardHeader>
-        <CardTitle>Users</CardTitle>
-        <CardDescription>
-          A user is what people using your product log into.
-        </CardDescription>
+      <CardHeader className="flex flex-row items-center justify-between space-x-4">
+        <div>
+          <CardTitle>Users</CardTitle>
+          <CardDescription>
+            A user is what people using your product log into.
+          </CardDescription>
+        </div>
+        <CreateUserButton
+          onSubmit={async () => {
+            await refetch();
+          }}
+        />
       </CardHeader>
       <CardContent>
         <Table>
@@ -84,3 +120,173 @@ export const OrganizationUsersTab = () => {
     </Card>
   );
 };
+
+interface CreateUserButtonProps {
+  onSubmit: () => Promise<void>;
+}
+
+const CreateUserButton: FC<CreateUserButtonProps> = ({ onSubmit }) => {
+  const { organizationId } = useParams();
+  const [open, setOpen] = useState(false);
+
+  const { data: organizationResponse } = useQuery(getOrganization, {
+    id: organizationId,
+  });
+
+  const form = useForm<z.infer<typeof userSchema>>({
+    defaultValues: {
+      email: '',
+      googleUserId: '',
+      microsoftUserId: '',
+      owner: false,
+    },
+  });
+
+  const createUserMutation = useMutation(createUser);
+
+  const handleSubmit = async (data: z.infer<typeof userSchema>) => {
+    try {
+      const newUser: Partial<User> = {
+        organizationId: organizationId as string,
+        email: data.email,
+        owner: data.owner,
+      };
+
+      if (data.googleUserId) {
+        newUser.googleUserId = data.googleUserId;
+      }
+
+      if (data.microsoftUserId) {
+        newUser.microsoftUserId = data.microsoftUserId;
+      }
+
+      await createUserMutation.mutateAsync({
+        user: newUser as User,
+      });
+
+      await onSubmit();
+      setOpen(false);
+
+      toast.success(`User created successfully!`);
+    } catch (error) {
+      console.error('Error creating user:', error);
+    }
+  };
+
+  return (
+    <AlertDialog open={open} onOpenChange={setOpen}>
+      <AlertDialogTrigger asChild>
+        <Button variant="outline" onClick={onSubmit}>
+          <CirclePlus />
+          Create User
+        </Button>
+      </AlertDialogTrigger>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Create User</AlertDialogTitle>
+          <AlertDialogDescription>
+            Create a new user in the{' '}
+            <span className="text-semibold">
+              {organizationResponse?.organization?.displayName}
+            </span>{' '}
+            Organization.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(handleSubmit)}>
+            <FormField
+              control={form.control}
+              name="email"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Email</FormLabel>
+                  <Input
+                    type="email"
+                    placeholder="jane.doe@example.com"
+                    {...field}
+                  />
+                  <FormDescription>
+                    The email address of the user being created.
+                  </FormDescription>
+                </FormItem>
+              )}
+            />
+
+            {organizationResponse?.organization?.logInWithGoogle && (
+              <FormField
+                control={form.control}
+                name="googleUserId"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>
+                      Google User ID{' '}
+                      <span className="font-normal text-sm">(optional)</span>
+                    </FormLabel>
+                    <Input placeholder="Google User ID" {...field} />
+                    <FormDescription>
+                      The Google User ID belonging to the user. This is
+                      optional, and will be set on the user automatically on a
+                      successful login attempt.
+                    </FormDescription>
+                  </FormItem>
+                )}
+              />
+            )}
+
+            {organizationResponse?.organization?.logInWithMicrosoft && (
+              <FormField
+                control={form.control}
+                name="microsoftUserId"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>
+                      Microsoft User ID{' '}
+                      <span className="font-normal text-sm">(optional)</span>
+                    </FormLabel>
+                    <Input placeholder="Microsoft User ID" {...field} />
+                    <FormDescription>
+                      The Microsoft User ID belonging to the user. This is
+                      optional, and will be set on the user automatically on a
+                      successful login attempt.
+                    </FormDescription>
+                  </FormItem>
+                )}
+              />
+            )}
+
+            <FormField
+              control={form.control}
+              name="owner"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Is Owner?</FormLabel>
+                  <Switch
+                    className="block"
+                    checked={field.value}
+                    onCheckedChange={field.onChange}
+                  />
+                  <FormDescription>
+                    Whether the user should be an owner of the organization.
+                    This will give them full access to the organization and all
+                    its resources.
+                  </FormDescription>
+                </FormItem>
+              )}
+            />
+            <AlertDialogFooter>
+              <AlertDialogCancel>Cancel</AlertDialogCancel>
+              <Button type="submit">Create</Button>
+            </AlertDialogFooter>
+          </form>
+        </Form>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+};
+
+const userSchema = z.object({
+  email: z.string().email(),
+  googleUserId: z.string().optional(),
+  microsoftUserId: z.string().optional(),
+  owner: z.boolean(),
+});

--- a/console/src/pages/organizations/OrganizationUsersTab.tsx
+++ b/console/src/pages/organizations/OrganizationUsersTab.tsx
@@ -23,7 +23,7 @@ import {
 import { Link } from 'react-router-dom';
 import { DateTime } from 'luxon';
 import { timestampDate } from '@bufbuild/protobuf/wkt';
-import { useParams } from 'react-router';
+import { useNavigate, useParams } from 'react-router';
 import { Badge } from '@/components/ui/badge';
 import {
   AlertDialog,
@@ -66,11 +66,7 @@ export const OrganizationUsersTab = () => {
             A user is what people using your product log into.
           </CardDescription>
         </div>
-        <CreateUserButton
-          onSubmit={async () => {
-            await refetch();
-          }}
-        />
+        <CreateUserButton />
       </CardHeader>
       <CardContent>
         <Table>
@@ -121,11 +117,9 @@ export const OrganizationUsersTab = () => {
   );
 };
 
-interface CreateUserButtonProps {
-  onSubmit: () => Promise<void>;
-}
+const CreateUserButton: FC = () => {
+  const navigate = useNavigate();
 
-const CreateUserButton: FC<CreateUserButtonProps> = ({ onSubmit }) => {
   const { organizationId } = useParams();
   const [open, setOpen] = useState(false);
 
@@ -160,12 +154,15 @@ const CreateUserButton: FC<CreateUserButtonProps> = ({ onSubmit }) => {
         newUser.microsoftUserId = data.microsoftUserId;
       }
 
-      await createUserMutation.mutateAsync({
+      const createUserResponse = await createUserMutation.mutateAsync({
         user: newUser as User,
       });
 
-      await onSubmit();
       setOpen(false);
+
+      navigate(
+        `/organizations/${organizationId}/users/${createUserResponse.user?.id}`,
+      );
 
       toast.success(`User created successfully!`);
     } catch (error) {
@@ -176,7 +173,7 @@ const CreateUserButton: FC<CreateUserButtonProps> = ({ onSubmit }) => {
   return (
     <AlertDialog open={open} onOpenChange={setOpen}>
       <AlertDialogTrigger asChild>
-        <Button variant="outline" onClick={onSubmit}>
+        <Button variant="outline">
           <CirclePlus />
           Create User
         </Button>

--- a/console/src/pages/organizations/OrganizationUsersTab.tsx
+++ b/console/src/pages/organizations/OrganizationUsersTab.tsx
@@ -60,7 +60,7 @@ export const OrganizationUsersTab = () => {
   return (
     <Card>
       <CardHeader className="flex flex-row items-center justify-between space-x-4">
-        <div>
+        <div className="flex flex-col space-y-1 5">
           <CardTitle>Users</CardTitle>
           <CardDescription>
             A user is what people using your product log into.
@@ -182,7 +182,7 @@ const CreateUserButton: FC = () => {
         <AlertDialogHeader>
           <AlertDialogTitle>Create User</AlertDialogTitle>
           <AlertDialogDescription>
-            Create a new user in the{' '}
+            Create a new User in the{' '}
             <span className="text-semibold">
               {organizationResponse?.organization?.displayName}
             </span>{' '}
@@ -206,7 +206,7 @@ const CreateUserButton: FC = () => {
                     {...field}
                   />
                   <FormDescription>
-                    The email address of the user being created.
+                    The email address of the User being created.
                   </FormDescription>
                 </FormItem>
               )}
@@ -224,8 +224,8 @@ const CreateUserButton: FC = () => {
                     </FormLabel>
                     <Input placeholder="Google User ID" {...field} />
                     <FormDescription>
-                      The Google User ID belonging to the user. This is
-                      optional, and will be set on the user automatically on a
+                      The Google User ID belonging to the User. This is
+                      optional, and will be set on the User automatically on a
                       successful login attempt.
                     </FormDescription>
                   </FormItem>
@@ -245,8 +245,8 @@ const CreateUserButton: FC = () => {
                     </FormLabel>
                     <Input placeholder="Microsoft User ID" {...field} />
                     <FormDescription>
-                      The Microsoft User ID belonging to the user. This is
-                      optional, and will be set on the user automatically on a
+                      The Microsoft User ID belonging to the User. This is
+                      optional, and will be set on the User automatically on a
                       successful login attempt.
                     </FormDescription>
                   </FormItem>
@@ -266,7 +266,7 @@ const CreateUserButton: FC = () => {
                     onCheckedChange={field.onChange}
                   />
                   <FormDescription>
-                    Whether the user should be an owner of the organization.
+                    Whether the User should be an owner of the organization.
                     This will give them full access to the organization and all
                     its resources.
                   </FormDescription>

--- a/console/src/pages/organizations/OrganizationUsersTab.tsx
+++ b/console/src/pages/organizations/OrganizationUsersTab.tsx
@@ -53,13 +53,13 @@ import { User } from '@/gen/tesseral/backend/v1/models_pb';
 
 export const OrganizationUsersTab = () => {
   const { organizationId } = useParams();
-  const { data: listUsersResponse, refetch } = useQuery(listUsers, {
+  const { data: listUsersResponse } = useQuery(listUsers, {
     organizationId,
   });
 
   return (
     <Card>
-      <CardHeader className="flex flex-row items-center justify-between space-x-4">
+      <CardHeader className="flex-row justify-between items-center space-x-4">
         <div className="flex flex-col space-y-1 5">
           <CardTitle>Users</CardTitle>
           <CardDescription>
@@ -259,7 +259,7 @@ const CreateUserButton: FC = () => {
               name="owner"
               render={({ field }) => (
                 <FormItem>
-                  <FormLabel>Is Owner?</FormLabel>
+                  <FormLabel>Owner</FormLabel>
                   <Switch
                     className="block"
                     checked={field.value}

--- a/console/src/pages/organizations/OrganizationUsersTab.tsx
+++ b/console/src/pages/organizations/OrganizationUsersTab.tsx
@@ -117,6 +117,13 @@ export const OrganizationUsersTab = () => {
   );
 };
 
+const schema = z.object({
+  email: z.string().email(),
+  googleUserId: z.string().optional(),
+  microsoftUserId: z.string().optional(),
+  owner: z.boolean(),
+});
+
 const CreateUserButton: FC = () => {
   const navigate = useNavigate();
 
@@ -127,7 +134,7 @@ const CreateUserButton: FC = () => {
     id: organizationId,
   });
 
-  const form = useForm<z.infer<typeof userSchema>>({
+  const form = useForm<z.infer<typeof schema>>({
     defaultValues: {
       email: '',
       googleUserId: '',
@@ -138,7 +145,7 @@ const CreateUserButton: FC = () => {
 
   const createUserMutation = useMutation(createUser);
 
-  const handleSubmit = async (data: z.infer<typeof userSchema>) => {
+  const handleSubmit = async (data: z.infer<typeof schema>) => {
     try {
       const newUser: Partial<User> = {
         organizationId: organizationId as string,
@@ -283,10 +290,3 @@ const CreateUserButton: FC = () => {
     </AlertDialog>
   );
 };
-
-const userSchema = z.object({
-  email: z.string().email(),
-  googleUserId: z.string().optional(),
-  microsoftUserId: z.string().optional(),
-  owner: z.boolean(),
-});

--- a/console/src/pages/organizations/OrganizationUsersTab.tsx
+++ b/console/src/pages/organizations/OrganizationUsersTab.tsx
@@ -193,7 +193,10 @@ const CreateUserButton: FC<CreateUserButtonProps> = ({ onSubmit }) => {
           </AlertDialogDescription>
         </AlertDialogHeader>
         <Form {...form}>
-          <form onSubmit={form.handleSubmit(handleSubmit)}>
+          <form
+            className="space-y-4"
+            onSubmit={form.handleSubmit(handleSubmit)}
+          >
             <FormField
               control={form.control}
               name="email"
@@ -273,7 +276,7 @@ const CreateUserButton: FC<CreateUserButtonProps> = ({ onSubmit }) => {
                 </FormItem>
               )}
             />
-            <AlertDialogFooter>
+            <AlertDialogFooter className="mt-8">
               <AlertDialogCancel>Cancel</AlertDialogCancel>
               <Button type="submit">Create</Button>
             </AlertDialogFooter>


### PR DESCRIPTION
This PR adds support for creating Organizations and Users from the console. Given the restrictions of the types of Organizations that can be associated with the Dogfood Project, there is also a check added to the `CreateOrganization` function in the backend store to prevent this RPC from being run on the Dogfood Project.

![Screenshot 2025-04-14 at 12 47 52 PM](https://github.com/user-attachments/assets/bf04ad1f-43a3-4f87-848c-6ca5a10b0ffc)
![Screenshot 2025-04-14 at 12 47 59 PM](https://github.com/user-attachments/assets/5cc02af7-fbeb-4743-a3a4-add21ebaa4f2)
![Screenshot 2025-04-14 at 12 48 10 PM](https://github.com/user-attachments/assets/5443dbb4-cf1c-45ad-aefe-b2a45778e5fc)
![Screenshot 2025-04-14 at 12 48 15 PM](https://github.com/user-attachments/assets/9809e358-7039-4b46-b174-6ba4ad365238)
