### PR TITLE
Prevent nginx from crashing locally

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -118,10 +118,6 @@ func main() {
 	}
 	defer db.Close()
 
-	if err := db.Ping(context.Background()); err != nil {
-		panic(fmt.Errorf("ping database: %w", err))
-	}
-
 	pageEncodingValue, err := hexkey.New(config.PageEncodingValue)
 	if err != nil {
 		panic(fmt.Errorf("parse page encoding secret: %w", err))

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -50,8 +50,6 @@ services:
     ports:
       - "80:80"
       - "443:443"
-    depends_on:
-      - api
     restart: always
     volumes:
       - ./.local/nginx:/etc/nginx/conf.d
@@ -64,7 +62,8 @@ services:
     ports:
       - "5432:5432"
     healthcheck:
-      test: ["CMD-SHELL", "PGPASSWORD=password pg_isready -U postgres -d postgres"]
+      test:
+        ["CMD-SHELL", "PGPASSWORD=password pg_isready -U postgres -d postgres"]
       interval: 10s
       retries: 5
       start_period: 30s


### PR DESCRIPTION
This PR removes the `depends_on` from nginx in docker-compose to prevent crashes when the api auto-rebuilds.

It also removes the db ping from the `api` startup.