### PR TITLE
[OPEN-362] Resolve React cookie management issues

### DIFF
--- a/console/src/App.tsx
+++ b/console/src/App.tsx
@@ -1,62 +1,33 @@
 import React, { FC, useMemo } from 'react';
-import EditProjectGoogleSettingsPage
-  from './pages/project/edit/EditProjectGoogleSettingsPage';
-import EditProjectMicrosoftSettingsPage
-  from './pages/project/edit/EditProjectMicrosoftSettingsPage';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { createConnectTransport } from '@connectrpc/connect-web';
 import { type Transport } from '@connectrpc/connect';
 import { TransportProvider } from '@connectrpc/connect-query';
 import { BrowserRouter, Route, Routes } from 'react-router-dom';
 import NotFoundPage from './pages/NotFound';
-import {
-  ListOrganizationsPage,
-} from '@/pages/organizations/ListOrganizationsPage';
-import {
-  ViewOrganizationPage,
-} from '@/pages/organizations/ViewOrganizationPage';
+import { ListOrganizationsPage } from '@/pages/organizations/ListOrganizationsPage';
+import { ViewOrganizationPage } from '@/pages/organizations/ViewOrganizationPage';
 import { ViewUserPage } from '@/pages/users/ViewUserPage';
 import { ListAPIKeysPage } from '@/pages/api-keys/ListAPIKeysPage';
-import {
-  ViewProjectSettingsPage,
-} from '@/pages/project/ViewProjectSettingsPage';
-import {
-  OrganizationUsersTab,
-} from '@/pages/organizations/OrganizationUsersTab';
-import {
-  OrganizationSAMLConnectionsTab,
-} from '@/pages/organizations/OrganizationSAMLConnectionsTab';
-import {
-  OrganizationSCIMAPIKeysTab,
-} from '@/pages/organizations/OrganizationSCIMAPIKeysTab';
-import {
-  OrganizationDetailsTab,
-} from '@/pages/organizations/OrganizationDetailsTab';
-import {
-  EditOrganizationPage,
-} from '@/pages/organizations/EditOrganizationPage';
-import {
-  ViewSAMLConnectionPage,
-} from '@/pages/saml-connections/ViewSAMLConnectionPage';
+import { ViewProjectSettingsPage } from '@/pages/project/ViewProjectSettingsPage';
+import { OrganizationUsersTab } from '@/pages/organizations/OrganizationUsersTab';
+import { OrganizationSAMLConnectionsTab } from '@/pages/organizations/OrganizationSAMLConnectionsTab';
+import { OrganizationSCIMAPIKeysTab } from '@/pages/organizations/OrganizationSCIMAPIKeysTab';
+import { OrganizationDetailsTab } from '@/pages/organizations/OrganizationDetailsTab';
+import { EditOrganizationPage } from '@/pages/organizations/EditOrganizationPage';
+import { ViewSAMLConnectionPage } from '@/pages/saml-connections/ViewSAMLConnectionPage';
 import { Toaster } from '@/components/ui/sonner';
-import {
-  EditSAMLConnectionPage,
-} from '@/pages/saml-connections/EditSAMLConnectionPage';
+import { EditSAMLConnectionPage } from '@/pages/saml-connections/EditSAMLConnectionPage';
 import { PageShell } from '@/components/page';
 import { ViewSCIMAPIKeyPage } from '@/pages/scim-api-keys/ViewSCIMAPIKeyPage';
 import { HomePage } from '@/pages/home/HomePage';
 import { ProjectDetailsTab } from '@/pages/project/ProjectDetailsTab';
 import { ViewPasskeyPage } from '@/pages/passkeys/ViewPasskeyPage';
-import {
-  OrganizationUserInvitesTab,
-} from '@/pages/organizations/OrganizationUserInvitesTab';
+import { OrganizationUserInvitesTab } from '@/pages/organizations/OrganizationUserInvitesTab';
 import { ViewUserInvitePage } from '@/pages/user-invites/ViewUserInvitePage';
 import { API_URL } from './config';
-import {
-  ViewPublishableKeyPage,
-} from '@/pages/api-keys/ViewPublishableKeyPage';
-import ProjectUISettingsPage
-  from './pages/project/project-ui-settings/ProjectUISettings';
+import { ViewPublishableKeyPage } from '@/pages/api-keys/ViewPublishableKeyPage';
+import ProjectUISettingsPage from './pages/project/project-ui-settings/ProjectUISettings';
 import { VaultDomainSettingsTab } from '@/pages/project/VaultDomainSettingsTab';
 import { ViewBackendAPIKeyPage } from '@/pages/api-keys/ViewBackendAPIKeyPage';
 import { LoginPage } from '@/pages/login/LoginPage';
@@ -64,35 +35,21 @@ import { SignupPage } from '@/pages/login/SignupPage';
 import { LoginFlowLayout } from '@/pages/login/LoginFlowLayout';
 import { VerifyEmailPage } from '@/pages/login/VerifyEmailPage';
 import { GoogleOAuthCallbackPage } from '@/pages/login/GoogleOAuthCallbackPage';
-import {
-  MicrosoftOAuthCallbackPage,
-} from '@/pages/login/MicrosoftOAuthCallbackPage';
+import { MicrosoftOAuthCallbackPage } from '@/pages/login/MicrosoftOAuthCallbackPage';
 import { ChooseOrganizationPage } from '@/pages/login/ChooseOrganizationPage';
 import { CreateOrganizationPage } from '@/pages/login/CreateOrganizationPage';
 import { OrganizationLoginPage } from '@/pages/login/OrganizationLoginPage';
-import {
-  AuthenticateAnotherWayPage,
-} from '@/pages/login/AuthenticateAnotherWayPage';
+import { AuthenticateAnotherWayPage } from '@/pages/login/AuthenticateAnotherWayPage';
 import { VerifyPasswordPage } from '@/pages/login/VerifyPasswordPage';
 import { ForgotPasswordPage } from '@/pages/login/ForgotPasswordPage';
-import {
-  VerifySecondaryFactorPage,
-} from '@/pages/login/VerifySecondaryFactorPage';
-import {
-  VerifyAuthenticatorAppPage,
-} from '@/pages/login/VerifyAuthenticatorAppPage';
-import {
-  VerifyAuthenticatorAppRecoveryCodePage,
-} from '@/pages/login/VerifyAuthenticatorAppRecoveryCodePage';
+import { VerifySecondaryFactorPage } from '@/pages/login/VerifySecondaryFactorPage';
+import { VerifyAuthenticatorAppPage } from '@/pages/login/VerifyAuthenticatorAppPage';
+import { VerifyAuthenticatorAppRecoveryCodePage } from '@/pages/login/VerifyAuthenticatorAppRecoveryCodePage';
 import { VerifyPasskeyPage } from '@/pages/login/VerifyPasskeyPage';
 import { RegisterPasswordPage } from '@/pages/login/RegisterPasswordPage';
-import {
-  RegisterSecondaryFactorPage,
-} from '@/pages/login/RegisterSecondaryFactorPage';
+import { RegisterSecondaryFactorPage } from '@/pages/login/RegisterSecondaryFactorPage';
 import { RegisterPasskeyPage } from '@/pages/login/RegisterPasskeyPage';
-import {
-  RegisterAuthenticatorAppPage,
-} from '@/pages/login/RegisterAuthenticatorAppPage';
+import { RegisterAuthenticatorAppPage } from '@/pages/login/RegisterAuthenticatorAppPage';
 import { FinishLoginPage } from '@/pages/login/FinishLoginPage';
 import { ImpersonatePage } from '@/pages/login/ImpersonatePage';
 import { SwitchOrganizationsPage } from '@/pages/login/SwitchOrganizationsPage';
@@ -109,7 +66,7 @@ const transport = createConnectTransport({
       ...init,
       credentials: 'include',
     }),
-})
+});
 
 const AppWithinQueryClient = () => {
   return (
@@ -172,10 +129,7 @@ const AppWithinQueryClient = () => {
               path="register-secondary-factor"
               element={<RegisterSecondaryFactorPage />}
             />
-            <Route
-              path="register-passkey"
-              element={<RegisterPasskeyPage />}
-            />
+            <Route path="register-passkey" element={<RegisterPasskeyPage />} />
             <Route
               path="register-authenticator-app"
               element={<RegisterAuthenticatorAppPage />}
@@ -201,17 +155,11 @@ const AppWithinQueryClient = () => {
                 path="vault-ui-settings"
                 element={<ProjectUISettingsPage />}
               />
-              <Route path="vault-domain-settings"
-                     element={<VaultDomainSettingsTab />} />
+              <Route
+                path="vault-domain-settings"
+                element={<VaultDomainSettingsTab />}
+              />
             </Route>
-            <Route
-              path="project-settings/log-in-with-google/edit"
-              element={<EditProjectGoogleSettingsPage />}
-            />
-            <Route
-              path="project-settings/log-in-with-microsoft/edit"
-              element={<EditProjectMicrosoftSettingsPage />}
-            />
 
             <Route
               path="project-settings/api-keys"
@@ -279,7 +227,10 @@ const AppWithinQueryClient = () => {
               element={<ViewSCIMAPIKeyPage />}
             />
 
-            <Route path="stripe-checkout-success" element={<StripeCheckoutSuccessPage />} />
+            <Route
+              path="stripe-checkout-success"
+              element={<StripeCheckoutSuccessPage />}
+            />
           </Route>
 
           <Route path="*" element={<NotFoundPage />} />

--- a/console/src/lib/AccessTokenProvider.tsx
+++ b/console/src/lib/AccessTokenProvider.tsx
@@ -18,7 +18,9 @@ export function useAccessToken() {
 
 function useAccessTokenInternal(): string | undefined {
   const [error, setError] = useState<unknown>();
-  const accessToken = getCookie(`tesseral_${DOGFOOD_PROJECT_ID}_access_token`);
+  const [accessToken, setAccessToken] = useState(() => {
+    return getCookie(`tesseral_${DOGFOOD_PROJECT_ID}_access_token`);
+  });
   const accessTokenLikelyValid = useAccessTokenLikelyValid(accessToken ?? '');
 
   // whenever the access token is invalid or near-expired, refresh it
@@ -47,7 +49,15 @@ function useAccessTokenInternal(): string | undefined {
         setError(
           `Unexpected response from /api/frontend/refresh: ${response.status}`,
         );
+        return;
       }
+
+      const { accessToken } = await response.json();
+      if (!accessToken) {
+        setError('No access token returned from /api/frontend/refresh');
+        return;
+      }
+      setAccessToken(accessToken);
     })();
   }, [accessTokenLikelyValid]);
 
@@ -92,7 +102,7 @@ function useDebouncedNow(updatePeriodMillis: number): number {
 
 function getCookie(key: string): string | undefined {
   return document.cookie
-    .split("; ")
-    .find((row) => row.startsWith(key + "="))
-    ?.split("=")[1];
+    .split('; ')
+    .find((row) => row.startsWith(key + '='))
+    ?.split('=')[1];
 }


### PR DESCRIPTION
This PR resolves issues with cookie management in React (the same issue we saw with [the SDK](https://github.com/tesseral-labs/tesseral-sdk-react/pull/4)). We're now holding returned access tokens in memory to get around the unreliability of document.cookie in the React lifecycle.

There was also an issue with some of the `App.tsx` imports and routes since Google and Microsoft settings are in modals now, so I resolved those to get the local build working.