### PR TITLE
saml: init: set text/html as content-type

### DIFF
--- a/internal/saml/service/service.go
+++ b/internal/saml/service/service.go
@@ -63,6 +63,7 @@ func (s *Service) init(w http.ResponseWriter, r *http.Request) error {
 		Now:        time.Now(),
 	})
 
+	w.Header().Set("Content-Type", "text/html")
 	if err := initTemplate.Execute(w, initTemplateData{
 		SignOnURL:   samlConnectionInitData.IDPRedirectURL,
 		SAMLRequest: initRes.SAMLRequest,


### PR DESCRIPTION
This is a regression introduced by changes to our load balancer setup. In the interest of keeping things simple, this PR has us explicitly set the content-type of the SAML init endpoint.