### PR TITLE
Fix side-by-side layout on mobile

### DIFF
--- a/vault-ui/src/pages/login/LoginPage.tsx
+++ b/vault-ui/src/pages/login/LoginPage.tsx
@@ -79,8 +79,8 @@ function CenteredLoginPage({ children }: { children?: React.ReactNode }) {
 
 function SideBySideLoginPage({ children }: { children?: React.ReactNode }) {
   return (
-    <div className="bg-background w-full min-h-screen grid grid-cols-2 gap-0">
-      <div className="bg-primary" />
+    <div className="bg-background w-full min-h-screen grid grid-cols-1 md:grid-cols-2 gap-0">
+      <div className="bg-primary hidden md:block" />
       <div className="flex flex-col justify-center items-center p-4">
         <div className="max-w-sm w-full mx-auto">{children}</div>
       </div>


### PR DESCRIPTION
This PR fixes some nasty mobile styles for the side-by-side vault login layout on mobile. Essentially, we just need to collapse the side panel (hide it) and use a single grid column on anything below `md` screens.

<img width="425" alt="Screenshot 2025-05-14 at 11 12 46 AM" src="https://github.com/user-attachments/assets/66200002-817e-4a9e-b804-c874db4f8ea9" />
<img width="423" alt="Screenshot 2025-05-14 at 11 12 32 AM" src="https://github.com/user-attachments/assets/5353a569-bdb0-43d5-b6e7-b83d8c6d2f56" />
