### PR TITLE
[OPEN-403] Fix api keys pages

### DIFF
--- a/console/src/App.tsx
+++ b/console/src/App.tsx
@@ -1,14 +1,12 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC } from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { createConnectTransport } from '@connectrpc/connect-web';
-import { type Transport } from '@connectrpc/connect';
 import { TransportProvider } from '@connectrpc/connect-query';
 import { BrowserRouter, Route, Routes } from 'react-router-dom';
 import NotFoundPage from './pages/NotFound';
 import { ListOrganizationsPage } from '@/pages/organizations/ListOrganizationsPage';
 import { ViewOrganizationPage } from '@/pages/organizations/ViewOrganizationPage';
 import { ViewUserPage } from '@/pages/users/ViewUserPage';
-import { ListAPIKeysPage } from '@/pages/api-keys/ListAPIKeysPage';
 import { ViewProjectSettingsPage } from '@/pages/project/ViewProjectSettingsPage';
 import { OrganizationUsersTab } from '@/pages/organizations/OrganizationUsersTab';
 import { OrganizationSAMLConnectionsTab } from '@/pages/organizations/OrganizationSAMLConnectionsTab';
@@ -54,7 +52,6 @@ import { FinishLoginPage } from '@/pages/login/FinishLoginPage';
 import { ImpersonatePage } from '@/pages/login/ImpersonatePage';
 import { SwitchOrganizationsPage } from '@/pages/login/SwitchOrganizationsPage';
 import { LogoutPage } from '@/pages/login/LogoutPage';
-import { useAccessToken } from '@/lib/AccessTokenProvider';
 import { StripeCheckoutSuccessPage } from './pages/stripe/StripeCheckoutSuccessPage';
 import { RBACSettingsTab } from '@/pages/project/RBACSettingsTab';
 import { EditRBACPolicyPage } from '@/pages/project/EditRBACPolicyPage';
@@ -63,6 +60,7 @@ import { OrganizationRolesTab } from '@/pages/organizations/OrganizationRolesTab
 import { CreateRolePage } from '@/pages/roles/CreateRolePage';
 import { EditRolePage } from '@/pages/roles/EditRolePage';
 import { GithubOAuthCallbackPage } from './pages/login/GithubOAuthCallbackPage';
+import { ListAPIKeysTab } from './pages/project/ListAPIKeysTab';
 
 const queryClient = new QueryClient();
 
@@ -171,16 +169,13 @@ const AppWithinQueryClient = () => {
                 element={<VaultDomainSettingsTab />}
               />
               <Route path="rbac-settings" element={<RBACSettingsTab />} />
+
+              <Route path="api-keys" element={<ListAPIKeysTab />} />
             </Route>
 
             <Route
               path="project-settings/rbac-settings/rbac-policy/edit"
               element={<EditRBACPolicyPage />}
-            />
-
-            <Route
-              path="project-settings/api-keys"
-              element={<ListAPIKeysPage />}
             />
 
             <Route

--- a/console/src/components/ConsoleNavigation.tsx
+++ b/console/src/components/ConsoleNavigation.tsx
@@ -87,7 +87,10 @@ const ConsoleNavigation: FC = () => {
                           <NavigationOrganizationPages slug={slug as any} />
                         ) : (
                           <div className="px-2 text-sm font-medium">
-                            {index === pathname.split('/').length - 1 ? (
+                            {index === pathname.split('/').length - 1 ||
+                            ['publishable-keys', 'backend-api-keys'].includes(
+                              slug,
+                            ) ? (
                               <span className="text-muted-foreground">
                                 {titleCaseSlug(
                                   slug,

--- a/console/src/pages/api-keys/ViewBackendAPIKeyPage.tsx
+++ b/console/src/pages/api-keys/ViewBackendAPIKeyPage.tsx
@@ -12,7 +12,9 @@ import { useNavigate, useParams } from 'react-router';
 import { useMutation, useQuery } from '@connectrpc/connect-query';
 import {
   deleteBackendAPIKey,
-  getBackendAPIKey, revokeBackendAPIKey, updateBackendAPIKey,
+  getBackendAPIKey,
+  revokeBackendAPIKey,
+  updateBackendAPIKey,
 } from '@/gen/tesseral/backend/v1/backend-BackendService_connectquery';
 import {
   Card,
@@ -50,7 +52,9 @@ import {
 import { Input } from '@/components/ui/input';
 import {
   PageCodeSubtitle,
+  PageContent,
   PageDescription,
+  PageHeader,
   PageTitle,
 } from '@/components/page';
 
@@ -60,102 +64,78 @@ export const ViewBackendAPIKeyPage = () => {
     id: backendApiKeyId,
   });
   return (
-    <div>
-      <Breadcrumb>
-        <BreadcrumbList>
-          <BreadcrumbItem>
-            <BreadcrumbLink asChild>
-              <Link to="/">Home</Link>
-            </BreadcrumbLink>
-          </BreadcrumbItem>
-          <BreadcrumbSeparator />
-          <BreadcrumbItem>
-            <BreadcrumbLink asChild>
-              <Link to="/project-settings">Project Settings</Link>
-            </BreadcrumbLink>
-          </BreadcrumbItem>
-          <BreadcrumbSeparator />
-          <BreadcrumbItem>
-            <BreadcrumbLink asChild>
-              <Link to="/project-settings/api-keys">API Keys</Link>
-            </BreadcrumbLink>
-          </BreadcrumbItem>
-          <BreadcrumbSeparator />
-          <BreadcrumbItem>
-            <BreadcrumbPage>
-              {getBackendApiKeyResponse?.backendApiKey?.displayName}
-            </BreadcrumbPage>
-          </BreadcrumbItem>
-        </BreadcrumbList>
-      </Breadcrumb>
+    <>
+      <PageHeader>
+        <PageTitle>
+          {getBackendApiKeyResponse?.backendApiKey?.displayName}
+        </PageTitle>
+        <PageCodeSubtitle>{backendApiKeyId}</PageCodeSubtitle>
+        <PageDescription>
+          Backend API keys are how your backend can automate operations in
+          Tesseral using the Tesseral Backend API.
+        </PageDescription>
+      </PageHeader>
 
-      <PageTitle>
-        {getBackendApiKeyResponse?.backendApiKey?.displayName}
-      </PageTitle>
-      <PageCodeSubtitle>{backendApiKeyId}</PageCodeSubtitle>
-      <PageDescription>
-        Backend API keys are how your backend can automate operations in
-        Tesseral using the Tesseral Backend API.
-      </PageDescription>
-
-      <Card className="my-8">
-        <CardHeader className="flex-row justify-between items-center">
-          <div className="flex flex-col space-y-1 5">
-            <CardTitle>Configuration</CardTitle>
-            <CardDescription>Details about your Backend API.</CardDescription>
-          </div>
-          <EditBackendAPIKeyButton />
-        </CardHeader>
-        <CardContent>
-          <div className="grid grid-cols-3 gap-x-2 text-sm">
-            <div className="border-r border-gray-200 pr-8 flex flex-col gap-4">
-              <div>
-                <div className="font-semibold">Display Name</div>
-                <div className="truncate">
-                  {getBackendApiKeyResponse?.backendApiKey?.displayName}
+      <PageContent>
+        <Card className="my-8">
+          <CardHeader className="flex-row justify-between items-center">
+            <div className="flex flex-col space-y-1 5">
+              <CardTitle>Configuration</CardTitle>
+              <CardDescription>Details about your Backend API.</CardDescription>
+            </div>
+            <EditBackendAPIKeyButton />
+          </CardHeader>
+          <CardContent>
+            <div className="grid grid-cols-3 gap-x-2 text-sm">
+              <div className="border-r border-gray-200 pr-8 flex flex-col gap-4">
+                <div>
+                  <div className="font-semibold">Display Name</div>
+                  <div className="truncate">
+                    {getBackendApiKeyResponse?.backendApiKey?.displayName}
+                  </div>
+                </div>
+                <div>
+                  <div className="font-semibold">Revoked</div>
+                  <div className="truncate">
+                    {getBackendApiKeyResponse?.backendApiKey?.revoked
+                      ? 'Yes'
+                      : 'No'}
+                  </div>
                 </div>
               </div>
-              <div>
-                <div className="font-semibold">Revoked</div>
-                <div className="truncate">
-                  {getBackendApiKeyResponse?.backendApiKey?.revoked
-                    ? 'Yes'
-                    : 'No'}
+              <div className="border-r border-gray-200 pr-8 pl-8 flex flex-col gap-4">
+                <div>
+                  <div className="font-semibold">Created</div>
+                  <div className="truncate">
+                    {getBackendApiKeyResponse?.backendApiKey?.createTime &&
+                      DateTime.fromJSDate(
+                        timestampDate(
+                          getBackendApiKeyResponse?.backendApiKey?.createTime,
+                        ),
+                      ).toRelative()}
+                  </div>
+                </div>
+              </div>
+              <div className="border-gray-200 pl-8 flex flex-col gap-4">
+                <div>
+                  <div className="font-semibold">Updated</div>
+                  <div className="truncate">
+                    {getBackendApiKeyResponse?.backendApiKey?.updateTime &&
+                      DateTime.fromJSDate(
+                        timestampDate(
+                          getBackendApiKeyResponse?.backendApiKey?.updateTime,
+                        ),
+                      ).toRelative()}
+                  </div>
                 </div>
               </div>
             </div>
-            <div className="border-r border-gray-200 pr-8 pl-8 flex flex-col gap-4">
-              <div>
-                <div className="font-semibold">Created</div>
-                <div className="truncate">
-                  {getBackendApiKeyResponse?.backendApiKey?.createTime &&
-                    DateTime.fromJSDate(
-                      timestampDate(
-                        getBackendApiKeyResponse?.backendApiKey?.createTime,
-                      ),
-                    ).toRelative()}
-                </div>
-              </div>
-            </div>
-            <div className="border-gray-200 pl-8 flex flex-col gap-4">
-              <div>
-                <div className="font-semibold">Updated</div>
-                <div className="truncate">
-                  {getBackendApiKeyResponse?.backendApiKey?.updateTime &&
-                    DateTime.fromJSDate(
-                      timestampDate(
-                        getBackendApiKeyResponse?.backendApiKey?.updateTime,
-                      ),
-                    ).toRelative()}
-                </div>
-              </div>
-            </div>
-          </div>
-        </CardContent>
-      </Card>
+          </CardContent>
+        </Card>
 
-      <DangerZoneCard />
-    </div>
+        <DangerZoneCard />
+      </PageContent>
+    </>
   );
 };
 
@@ -172,7 +152,7 @@ const EditBackendAPIKeyButton = () => {
     },
   );
   const updateBackendAPIKeyMutation = useMutation(updateBackendAPIKey);
-   
+
   // Currently there's an issue with the types of react-hook-form and zod
   // preventing the compiler from inferring the correct types.
   const form = useForm<z.infer<typeof schema>>({
@@ -188,7 +168,6 @@ const EditBackendAPIKeyButton = () => {
       });
     }
   }, [getBackendAPIKeyResponse]);
-   
 
   const [open, setOpen] = useState(false);
 
@@ -216,11 +195,11 @@ const EditBackendAPIKeyButton = () => {
           </AlertDialogDescription>
         </AlertDialogHeader>
         <Form {...form}>
-          { }
+          {}
           {/** Currently there's an issue with the types of react-hook-form and zod
           preventing the compiler from inferring the correct types.*/}
           <form onSubmit={form.handleSubmit(handleSubmit)}>
-            { }
+            {}
             <FormField
               control={form.control}
               name="displayName"

--- a/console/src/pages/api-keys/ViewPublishableKeyPage.tsx
+++ b/console/src/pages/api-keys/ViewPublishableKeyPage.tsx
@@ -51,7 +51,9 @@ import {
 import { Input } from '@/components/ui/input';
 import {
   PageCodeSubtitle,
+  PageContent,
   PageDescription,
+  PageHeader,
   PageTitle,
 } from '@/components/page';
 
@@ -62,104 +64,81 @@ export const ViewPublishableKeyPage = () => {
   });
 
   return (
-    <div>
-      <Breadcrumb>
-        <BreadcrumbList>
-          <BreadcrumbItem>
-            <BreadcrumbLink asChild>
-              <Link to="/">Home</Link>
-            </BreadcrumbLink>
-          </BreadcrumbItem>
-          <BreadcrumbSeparator />
-          <BreadcrumbItem>
-            <BreadcrumbLink asChild>
-              <Link to="/project-settings">Project Settings</Link>
-            </BreadcrumbLink>
-          </BreadcrumbItem>
-          <BreadcrumbSeparator />
-          <BreadcrumbItem>
-            <BreadcrumbLink asChild>
-              <Link to="/project-settings/api-keys">API Keys</Link>
-            </BreadcrumbLink>
-          </BreadcrumbItem>
-          <BreadcrumbSeparator />
-          <BreadcrumbItem>
-            <BreadcrumbPage>
-              {getPublishableKeyResponse?.publishableKey?.displayName}
-            </BreadcrumbPage>
-          </BreadcrumbItem>
-        </BreadcrumbList>
-      </Breadcrumb>
+    <>
+      <PageHeader>
+        <PageTitle>
+          {getPublishableKeyResponse?.publishableKey?.displayName}
+        </PageTitle>
+        <PageCodeSubtitle>{publishableKeyId}</PageCodeSubtitle>
+        <PageDescription>
+          Tesseral's client-side SDKs require a Publishable Key. Publishable
+          Keys can safely be publicly accessible in your web or mobile app's
+          client-side code.
+        </PageDescription>
+      </PageHeader>
 
-      <PageTitle>
-        {getPublishableKeyResponse?.publishableKey?.displayName}
-      </PageTitle>
-      <PageCodeSubtitle>{publishableKeyId}</PageCodeSubtitle>
-      <PageDescription>
-        Tesseral's client-side SDKs require a Publishable Key. Publishable Keys
-        can safely be publicly accessible in your web or mobile app's
-        client-side code.
-      </PageDescription>
-
-      <Card className="my-8">
-        <CardHeader className="flex-row justify-between items-center">
-          <div className="flex flex-col space-y-1 5">
-            <CardTitle>Configuration</CardTitle>
-            <CardDescription>Details about this Publishable Key.</CardDescription>
-          </div>
-          <EditPublishableKeyButton />
-        </CardHeader>
-        <CardContent>
-          <div className="grid grid-cols-3 gap-x-2 text-sm">
-            <div className="border-r border-gray-200 pr-8 flex flex-col gap-4">
-              <div>
-                <div className="font-semibold">Display Name</div>
-                <div className="truncate">
-                  {getPublishableKeyResponse?.publishableKey?.displayName}
+      <PageContent>
+        <Card className="my-8">
+          <CardHeader className="flex-row justify-between items-center">
+            <div className="flex flex-col space-y-1 5">
+              <CardTitle>Configuration</CardTitle>
+              <CardDescription>
+                Details about this Publishable Key.
+              </CardDescription>
+            </div>
+            <EditPublishableKeyButton />
+          </CardHeader>
+          <CardContent>
+            <div className="grid grid-cols-3 gap-x-2 text-sm">
+              <div className="border-r border-gray-200 pr-8 flex flex-col gap-4">
+                <div>
+                  <div className="font-semibold">Display Name</div>
+                  <div className="truncate">
+                    {getPublishableKeyResponse?.publishableKey?.displayName}
+                  </div>
+                </div>
+                <div>
+                  <div className="font-semibold">Dev Mode</div>
+                  <div className="truncate">
+                    {getPublishableKeyResponse?.publishableKey?.devMode
+                      ? 'Enabled'
+                      : 'Disabled'}
+                  </div>
                 </div>
               </div>
-              <div>
-                <div className="font-semibold">Dev Mode</div>
-                <div className="truncate">
-                  {getPublishableKeyResponse?.publishableKey
-                    ?.devMode
-                    ? 'Enabled'
-                    : 'Disabled'}
+              <div className="border-r border-gray-200 pr-8 pl-8 flex flex-col gap-4">
+                <div>
+                  <div className="font-semibold">Created</div>
+                  <div className="truncate">
+                    {getPublishableKeyResponse?.publishableKey?.createTime &&
+                      DateTime.fromJSDate(
+                        timestampDate(
+                          getPublishableKeyResponse?.publishableKey?.createTime,
+                        ),
+                      ).toRelative()}
+                  </div>
+                </div>
+              </div>
+              <div className="border-gray-200 pl-8 flex flex-col gap-4">
+                <div>
+                  <div className="font-semibold">Updated</div>
+                  <div className="truncate">
+                    {getPublishableKeyResponse?.publishableKey?.updateTime &&
+                      DateTime.fromJSDate(
+                        timestampDate(
+                          getPublishableKeyResponse?.publishableKey?.updateTime,
+                        ),
+                      ).toRelative()}
+                  </div>
                 </div>
               </div>
             </div>
-            <div className="border-r border-gray-200 pr-8 pl-8 flex flex-col gap-4">
-              <div>
-                <div className="font-semibold">Created</div>
-                <div className="truncate">
-                  {getPublishableKeyResponse?.publishableKey?.createTime &&
-                    DateTime.fromJSDate(
-                      timestampDate(
-                        getPublishableKeyResponse?.publishableKey?.createTime,
-                      ),
-                    ).toRelative()}
-                </div>
-              </div>
-            </div>
-            <div className="border-gray-200 pl-8 flex flex-col gap-4">
-              <div>
-                <div className="font-semibold">Updated</div>
-                <div className="truncate">
-                  {getPublishableKeyResponse?.publishableKey?.updateTime &&
-                    DateTime.fromJSDate(
-                      timestampDate(
-                        getPublishableKeyResponse?.publishableKey?.updateTime,
-                      ),
-                    ).toRelative()}
-                </div>
-              </div>
-            </div>
-          </div>
-        </CardContent>
-      </Card>
+          </CardContent>
+        </Card>
 
-      <DangerZoneCard />
-    </div>
+        <DangerZoneCard />
+      </PageContent>
+    </>
   );
 };
 

--- a/console/src/pages/project/ListAPIKeysTab.tsx
+++ b/console/src/pages/project/ListAPIKeysTab.tsx
@@ -20,14 +20,11 @@ import React, { useState } from 'react';
 import { DateTime } from 'luxon';
 import { timestampDate } from '@bufbuild/protobuf/wkt';
 import {
-  Breadcrumb,
-  BreadcrumbItem,
-  BreadcrumbLink,
-  BreadcrumbList,
-  BreadcrumbPage,
-  BreadcrumbSeparator,
-} from '@/components/ui/breadcrumb';
-import { PageDescription, PageTitle } from '@/components/page';
+  PageContent,
+  PageDescription,
+  PageHeader,
+  PageTitle,
+} from '@/components/page';
 import {
   Card,
   CardContent,
@@ -63,7 +60,7 @@ import {
 import { Input } from '@/components/ui/input';
 import { Switch } from '@/components/ui/switch';
 
-export const ListAPIKeysPage = () => {
+export const ListAPIKeysTab = () => {
   const { data: getProjectEntitlementsResponse } = useQuery(
     getProjectEntitlements,
     {},
@@ -84,80 +81,136 @@ export const ListAPIKeysPage = () => {
   const { data: listBackendAPIKeysResponse } = useQuery(listBackendAPIKeys, {});
 
   return (
-    <div>
-      <Breadcrumb>
-        <BreadcrumbList>
-          <BreadcrumbItem>
-            <BreadcrumbLink asChild>
-              <Link to="/">Home</Link>
-            </BreadcrumbLink>
-          </BreadcrumbItem>
-          <BreadcrumbSeparator />
-          <BreadcrumbItem>
-            <BreadcrumbLink asChild>
-              <Link to="/project-settings">Project Settings</Link>
-            </BreadcrumbLink>
-          </BreadcrumbItem>
-          <BreadcrumbSeparator />
-          <BreadcrumbItem>
-            <BreadcrumbPage>API Keys</BreadcrumbPage>
-          </BreadcrumbItem>
-        </BreadcrumbList>
-      </Breadcrumb>
+    <div className="mt-8 space-y-8">
+      <Card>
+        <CardHeader className="flex-row justify-between items-center">
+          <div className="flex flex-col space-y-1 5">
+            <CardTitle>Publishable Keys</CardTitle>
+            <CardDescription>
+              Tesseral's client-side SDKs require a publishable key. Publishable
+              keys can be publicly accessible in your web or mobile app's
+              client-side code.
+            </CardDescription>
+          </div>
+          <CreatePublishableKeyButton />
+        </CardHeader>
+        <CardContent>
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableCell>Display Name</TableCell>
+                <TableHead>ID</TableHead>
+                <TableHead>Created</TableHead>
+                <TableHead>Updated</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {listPublishableKeysResponse?.publishableKeys?.map(
+                (publishableKey) => (
+                  <TableRow key={publishableKey.id}>
+                    <TableCell className="font-medium">
+                      <Link
+                        className="font-medium underline underline-offset-2 decoration-muted-foreground/40"
+                        to={`/project-settings/api-keys/publishable-keys/${publishableKey.id}`}
+                      >
+                        {publishableKey.displayName}
+                      </Link>
+                    </TableCell>
+                    <TableCell className="font-mono">
+                      {publishableKey.id}
+                    </TableCell>
+                    <TableCell>
+                      {publishableKey.createTime &&
+                        DateTime.fromJSDate(
+                          timestampDate(publishableKey.createTime),
+                        ).toRelative()}
+                    </TableCell>
+                    <TableCell>
+                      {publishableKey.updateTime &&
+                        DateTime.fromJSDate(
+                          timestampDate(publishableKey.updateTime),
+                        ).toRelative()}
+                    </TableCell>
+                  </TableRow>
+                ),
+              )}
+            </TableBody>
+          </Table>
+        </CardContent>
+      </Card>
 
-      <PageTitle>API Keys</PageTitle>
-      <PageDescription className="mt-2">
-        API Keys for your Tesseral Project.
-      </PageDescription>
+      <Card>
+        <CardHeader className="flex-row justify-between items-center">
+          <div className="flex flex-col space-y-1 5">
+            <CardTitle>Backend API Keys</CardTitle>
+            <CardDescription>
+              Backend API keys are how your backend can automate operations in
+              Tesseral using the Tesseral Backend API.
+            </CardDescription>
+          </div>
+          <CreateBackendAPIKeyButton />
+        </CardHeader>
+        <CardContent>
+          {/* do not treat undefined as unentitled, to avoid flickering here */}
+          {getProjectEntitlementsResponse?.entitledBackendApiKeys === false ? (
+            <div className="text-sm my-8 w-full flex flex-col items-center justify-center space-y-6">
+              <div className="font-medium">
+                Backend API Keys are available on the Growth Tier.
+              </div>
 
-      <div className="mt-8 space-y-8">
-        <Card>
-          <CardHeader className="flex-row justify-between items-center">
-            <div className="flex flex-col space-y-1 5">
-              <CardTitle>Publishable Keys</CardTitle>
-              <CardDescription>
-                Tesseral's client-side SDKs require a publishable key.
-                Publishable keys can be publicly accessible in your web or
-                mobile app's client-side code.
-              </CardDescription>
+              <div className="flex items-center gap-x-4">
+                <Button onClick={handleUpgrade}>Upgrade to Growth Tier</Button>
+                <span>
+                  or{' '}
+                  <a
+                    href="https://cal.com/ned-o-leary-j8ydyi/30min"
+                    className="font-medium underline underline-offset-2 decoration-muted-foreground/40"
+                  >
+                    meet an expert
+                  </a>
+                  .
+                </span>
+              </div>
             </div>
-            <CreatePublishableKeyButton />
-          </CardHeader>
-          <CardContent>
+          ) : (
             <Table>
               <TableHeader>
                 <TableRow>
                   <TableCell>Display Name</TableCell>
                   <TableHead>ID</TableHead>
-                  <TableHead>Created</TableHead>
-                  <TableHead>Updated</TableHead>
+                  <TableHead>Status</TableHead>
+                  <TableHead>Created At</TableHead>
+                  <TableHead>Updated At</TableHead>
                 </TableRow>
               </TableHeader>
               <TableBody>
-                {listPublishableKeysResponse?.publishableKeys?.map(
-                  (publishableKey) => (
-                    <TableRow key={publishableKey.id}>
+                {listBackendAPIKeysResponse?.backendApiKeys?.map(
+                  (backendApiKey) => (
+                    <TableRow key={backendApiKey.id}>
                       <TableCell className="font-medium">
                         <Link
                           className="font-medium underline underline-offset-2 decoration-muted-foreground/40"
-                          to={`/project-settings/api-keys/publishable-keys/${publishableKey.id}`}
+                          to={`/project-settings/api-keys/backend-api-keys/${backendApiKey.id}`}
                         >
-                          {publishableKey.displayName}
+                          {backendApiKey.displayName}
                         </Link>
                       </TableCell>
                       <TableCell className="font-mono">
-                        {publishableKey.id}
+                        {backendApiKey.id}
                       </TableCell>
                       <TableCell>
-                        {publishableKey.createTime &&
+                        {backendApiKey?.revoked ? 'Revoked' : 'Active'}
+                      </TableCell>
+                      <TableCell>
+                        {backendApiKey.createTime &&
                           DateTime.fromJSDate(
-                            timestampDate(publishableKey.createTime),
+                            timestampDate(backendApiKey.createTime),
                           ).toRelative()}
                       </TableCell>
                       <TableCell>
-                        {publishableKey.updateTime &&
+                        {backendApiKey.updateTime &&
                           DateTime.fromJSDate(
-                            timestampDate(publishableKey.updateTime),
+                            timestampDate(backendApiKey.updateTime),
                           ).toRelative()}
                       </TableCell>
                     </TableRow>
@@ -165,94 +218,9 @@ export const ListAPIKeysPage = () => {
                 )}
               </TableBody>
             </Table>
-          </CardContent>
-        </Card>
-
-        <Card>
-          <CardHeader className="flex-row justify-between items-center">
-            <div className="flex flex-col space-y-1 5">
-              <CardTitle>Backend API Keys</CardTitle>
-              <CardDescription>
-                Backend API keys are how your backend can automate operations in
-                Tesseral using the Tesseral Backend API.
-              </CardDescription>
-            </div>
-            <CreateBackendAPIKeyButton />
-          </CardHeader>
-          <CardContent>
-            {/* do not treat undefined as unentitled, to avoid flickering here */}
-            {getProjectEntitlementsResponse?.entitledBackendApiKeys === false ? (
-              <div className="text-sm my-8 w-full flex flex-col items-center justify-center space-y-6">
-                <div className="font-medium">
-                  Backend API Keys are available on the Growth Tier.
-                </div>
-
-                <div className="flex items-center gap-x-4">
-                  <Button onClick={handleUpgrade}>
-                    Upgrade to Growth Tier
-                  </Button>
-                  <span>
-                    or{' '}
-                    <a
-                      href="https://cal.com/ned-o-leary-j8ydyi/30min"
-                      className="font-medium underline underline-offset-2 decoration-muted-foreground/40"
-                    >
-                      meet an expert
-                    </a>
-                    .
-                  </span>
-                </div>
-              </div>
-            ) : (
-              <Table>
-                <TableHeader>
-                  <TableRow>
-                    <TableCell>Display Name</TableCell>
-                    <TableHead>ID</TableHead>
-                    <TableHead>Status</TableHead>
-                    <TableHead>Created At</TableHead>
-                    <TableHead>Updated At</TableHead>
-                  </TableRow>
-                </TableHeader>
-                <TableBody>
-                  {listBackendAPIKeysResponse?.backendApiKeys?.map(
-                    (backendApiKey) => (
-                      <TableRow key={backendApiKey.id}>
-                        <TableCell className="font-medium">
-                          <Link
-                            className="font-medium underline underline-offset-2 decoration-muted-foreground/40"
-                            to={`/project-settings/api-keys/backend-api-keys/${backendApiKey.id}`}
-                          >
-                            {backendApiKey.displayName}
-                          </Link>
-                        </TableCell>
-                        <TableCell className="font-mono">
-                          {backendApiKey.id}
-                        </TableCell>
-                        <TableCell>
-                          {backendApiKey?.revoked ? 'Revoked' : 'Active'}
-                        </TableCell>
-                        <TableCell>
-                          {backendApiKey.createTime &&
-                            DateTime.fromJSDate(
-                              timestampDate(backendApiKey.createTime),
-                            ).toRelative()}
-                        </TableCell>
-                        <TableCell>
-                          {backendApiKey.updateTime &&
-                            DateTime.fromJSDate(
-                              timestampDate(backendApiKey.updateTime),
-                            ).toRelative()}
-                        </TableCell>
-                      </TableRow>
-                    ),
-                  )}
-                </TableBody>
-              </Table>
-            )}
-          </CardContent>
-        </Card>
-      </div>
+          )}
+        </CardContent>
+      </Card>
     </div>
   );
 };

--- a/console/src/pages/project/ViewProjectSettingsPage.tsx
+++ b/console/src/pages/project/ViewProjectSettingsPage.tsx
@@ -44,6 +44,10 @@ export const ViewProjectSettingsPage = () => {
       name: 'Role-Based Access Control Settings',
       url: `/project-settings/rbac-settings`,
     },
+    {
+      name: 'API Keys',
+      url: `/project-settings/api-keys`,
+    },
   ];
 
   const currentTab = tabs.find((tab) => tab.url === pathname);


### PR DESCRIPTION
This PR fixes the API Key pages' discoverability within the console by moving the API Keys page to a tab in Project Settings.

To accommodate this change, a small exception was added to the navigation to exclude link creation for `publishable-keys` and `backend-api-keys`, since those routes don't exist independently.

![Screenshot 2025-05-15 at 1 46 41 PM](https://github.com/user-attachments/assets/362fa35b-bff1-4840-a0f4-203eb231f0b6)
![Screenshot 2025-05-15 at 1 46 31 PM](https://github.com/user-attachments/assets/1a197d1a-9d93-45a2-bf89-4f7ed7156ce3)
![Screenshot 2025-05-15 at 1 46 52 PM](https://github.com/user-attachments/assets/a560354c-d1b2-48ef-aa16-971e5c12ed12)
