### PR TITLE
Simplify nginx configuration and force lazy DNS resolution

### DIFF
--- a/.local/nginx/default.conf
+++ b/.local/nginx/default.conf
@@ -8,8 +8,8 @@ server {
   resolver 127.0.0.11 valid=1s;
 
   location / {
-    set $upstream http://api:3001/api/backend;
-    proxy_pass $upstream$request_uri;
+    set $upstream http://api:3001/api/backend$request_uri;
+    proxy_pass $upstream;
   }
 }
 
@@ -23,8 +23,8 @@ server {
   resolver 127.0.0.11 valid=1s;
 
   location / {
-    set $upstream http://api:3001/api/config-api;
-    proxy_pass $upstream$request_uri;
+    set $upstream http://api:3001/api/config-api$request_uri;
+    proxy_pass $upstream;
   }
 }
 

--- a/.local/nginx/default.conf
+++ b/.local/nginx/default.conf
@@ -1,174 +1,136 @@
 server {
-  listen 443 ssl;
-  listen [::]:443 ssl;
-  ssl_certificate /etc/nginx/conf.d/api.tesseral.example.com.pem;
-  ssl_certificate_key /etc/nginx/conf.d/api.tesseral.example.com-key.pem;
   server_name api.tesseral.example.com;
 
-  location / {
-    proxy_http_version 1.1;
-    proxy_connect_timeout 5s;
-    proxy_next_upstream error timeout http_500 http_502 http_503 http_504;
-    proxy_read_timeout 10s;
-    proxy_send_timeout 10s;
-    proxy_set_header Connection "upgrade";
-    proxy_set_header Host $host;
-    proxy_set_header Upgrade $http_upgrade;
-    proxy_set_header X-Real-IP $remote_addr;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header X-Forwarded-Proto $scheme;
+  listen 443 ssl;
+  ssl_certificate /etc/nginx/conf.d/api.tesseral.example.com.pem;
+  ssl_certificate_key /etc/nginx/conf.d/api.tesseral.example.com-key.pem;
 
-    set $upstream http://api:3001/api/backend/;
-    proxy_pass $upstream;
+  resolver 127.0.0.11 valid=1s;
+
+  location / {
+    set $upstream http://api:3001/api/backend;
+    proxy_pass $upstream$request_uri;
   }
 }
 
 server {
-  listen 443 ssl;
-  listen [::]:443 ssl;
-  ssl_certificate /etc/nginx/conf.d/config.tesseral.example.com.pem;
-  ssl_certificate_key /etc/nginx/conf.d/config.tesseral.example.com-key.pem;
   server_name config.tesseral.example.com;
 
-  location / {
-    proxy_http_version 1.1;
-    proxy_connect_timeout 5s;
-    proxy_next_upstream error timeout http_500 http_502 http_503 http_504;
-    proxy_read_timeout 10s;
-    proxy_send_timeout 10s;
-    proxy_set_header Connection "upgrade";
-    proxy_set_header Host $host;
-    proxy_set_header Upgrade $http_upgrade;
-    proxy_set_header X-Real-IP $remote_addr;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header X-Forwarded-Proto $scheme;
+  listen 443 ssl;
+  ssl_certificate /etc/nginx/conf.d/config.tesseral.example.com.pem;
+  ssl_certificate_key /etc/nginx/conf.d/config.tesseral.example.com-key.pem;
 
-    set $upstream http://api:3001/api/config-api/;
+  resolver 127.0.0.11 valid=1s;
+
+  location / {
+    set $upstream http://api:3001/api/config-api;
+    proxy_pass $upstream$request_uri;
+  }
+}
+
+server {
+  server_name console.tesseral.example.com;
+
+  listen 443 ssl;
+  ssl_certificate /etc/nginx/conf.d/console.tesseral.example.com.pem;
+  ssl_certificate_key /etc/nginx/conf.d/console.tesseral.example.com-key.pem;
+
+  resolver 127.0.0.11 valid=1s;
+
+  location / {
+    set $upstream http://console:3000;
     proxy_pass $upstream;
   }
 }
 
 server {
-  listen 443 ssl;
-  listen [::]:443 ssl;
-  ssl_certificate /etc/nginx/conf.d/console.tesseral.example.com.pem;
-  ssl_certificate_key /etc/nginx/conf.d/console.tesseral.example.com-key.pem;
-  server_name console.tesseral.example.com;
-
-  location / {
-    proxy_http_version 1.1;
-    proxy_next_upstream error timeout http_500 http_502 http_503 http_504;
-    proxy_read_timeout 10s;
-    proxy_send_timeout 10s;
-    proxy_set_header Connection "upgrade";
-    proxy_set_header Host $host;
-    proxy_set_header Upgrade $http_upgrade;
-    proxy_set_header X-Real-IP $remote_addr;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header X-Forwarded-Proto $scheme;
-
-    proxy_pass http://console:3000/;
-  }
-}
-
-server {
-  listen 443 ssl;
-  listen [::]:443 ssl;
-  ssl_certificate /etc/nginx/conf.d/vault.console.tesseral.example.com.pem;
-  ssl_certificate_key /etc/nginx/conf.d/vault.console.tesseral.example.com-key.pem;
-  server_name vault.console.tesseral.example.com;
-
-  include /etc/nginx/conf.d/includes/vault.conf;
-}
-
-server {
-  listen 443 ssl;
-  listen [::]:443 ssl;
-  ssl_certificate /etc/nginx/conf.d/wildcard.tesseral.example.app.pem;
-  ssl_certificate_key /etc/nginx/conf.d/wildcard.tesseral.example.app-key.pem;
-  server_name *.tesseral.example.app;
-
-  include /etc/nginx/conf.d/includes/vault.conf;
-}
-
-server {
-  listen 443 ssl;
-  listen [::]:443 ssl;
-  ssl_certificate /etc/nginx/conf.d/vault.app.company1.example.com.pem;
-  ssl_certificate_key /etc/nginx/conf.d/vault.app.company1.example.com-key.pem;
-  server_name vault.app.company1.example.com;
-
-  include /etc/nginx/conf.d/includes/vault.conf;
-}
-
-server {
-  listen 443 ssl;
-  listen [::]:443 ssl;
-  ssl_certificate /etc/nginx/conf.d/app.company1.example.com.pem;
-  ssl_certificate_key /etc/nginx/conf.d/app.company1.example.com-key.pem;
-  server_name app.company1.example.com;
-
-  location / {
-    default_type text/html;
-    return 200 "";
-  }
-}
-
-server {
-  listen 443 ssl;
-  listen [::]:443 ssl;
-  ssl_certificate /etc/nginx/conf.d/vault.company2.example.com.pem;
-  ssl_certificate_key /etc/nginx/conf.d/vault.company2.example.com-key.pem;
-  server_name vault.company2.example.com;
-
-  include /etc/nginx/conf.d/includes/vault.conf;
-}
-
-server {
-  listen 443 ssl;
-  listen [::]:443 ssl;
-  ssl_certificate /etc/nginx/conf.d/company2.example.com.pem;
-  ssl_certificate_key /etc/nginx/conf.d/company2.example.com-key.pem;
-  server_name company2.example.com;
-
-  location / {
-    default_type text/html;
-    return 200 "";
-  }
-}
-
-server {
-  listen 443 ssl;
-  listen [::]:443 ssl;
-  ssl_certificate /etc/nginx/conf.d/app.company3.example.com.pem;
-  ssl_certificate_key /etc/nginx/conf.d/app.company3.example.com-key.pem;
-  server_name app.company3.example.com;
-
-  location / {
-    default_type text/html;
-    return 200 "";
-  }
-}
-
-server {
-  listen 443 ssl;
-  listen [::]:443 ssl;
-  ssl_certificate /etc/nginx/conf.d/tesseralusercontent.example.com.pem;
-  ssl_certificate_key /etc/nginx/conf.d/tesseralusercontent.example.com-key.pem;
   server_name tesseralusercontent.example.com;
 
-  location / {
-    proxy_http_version 1.1;
-    proxy_next_upstream error timeout http_500 http_502 http_503 http_504;
-    proxy_read_timeout 10s;
-    proxy_send_timeout 10s;
-    proxy_set_header Connection "upgrade";
-    proxy_set_header Host $host;
-    proxy_set_header Upgrade $http_upgrade;
-    proxy_set_header X-Real-IP $remote_addr;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header X-Forwarded-Proto $scheme;
+  listen 443 ssl;
+  ssl_certificate /etc/nginx/conf.d/tesseralusercontent.example.com.pem;
+  ssl_certificate_key /etc/nginx/conf.d/tesseralusercontent.example.com-key.pem;
 
-    proxy_pass http://s3:9090/;
+  location / {
+    set $upstream http://s3:9090;
+    proxy_pass $upstream;
+  }
+}
+
+server {
+  server_name vault.console.tesseral.example.com;
+
+  listen 443 ssl;
+  ssl_certificate /etc/nginx/conf.d/vault.console.tesseral.example.com.pem;
+  ssl_certificate_key /etc/nginx/conf.d/vault.console.tesseral.example.com-key.pem;
+
+  include /etc/nginx/conf.d/includes/vault.conf;
+}
+
+server {
+  server_name *.tesseral.example.app;
+
+  listen 443 ssl;
+  ssl_certificate /etc/nginx/conf.d/wildcard.tesseral.example.app.pem;
+  ssl_certificate_key /etc/nginx/conf.d/wildcard.tesseral.example.app-key.pem;
+
+  include /etc/nginx/conf.d/includes/vault.conf;
+}
+
+server {
+  server_name vault.app.company1.example.com;
+
+  listen 443 ssl;
+  ssl_certificate /etc/nginx/conf.d/vault.app.company1.example.com.pem;
+  ssl_certificate_key /etc/nginx/conf.d/vault.app.company1.example.com-key.pem;
+
+  include /etc/nginx/conf.d/includes/vault.conf;
+}
+
+server {
+  server_name app.company1.example.com;
+
+  listen 443 ssl;
+  ssl_certificate /etc/nginx/conf.d/app.company1.example.com.pem;
+  ssl_certificate_key /etc/nginx/conf.d/app.company1.example.com-key.pem;
+
+  location / {
+    default_type text/html;
+    return 200 "";
+  }
+}
+
+server {
+  server_name vault.company2.example.com;
+
+  listen 443 ssl;
+  ssl_certificate /etc/nginx/conf.d/vault.company2.example.com.pem;
+  ssl_certificate_key /etc/nginx/conf.d/vault.company2.example.com-key.pem;
+
+  include /etc/nginx/conf.d/includes/vault.conf;
+}
+
+server {
+  server_name company2.example.com;
+
+  listen 443 ssl;
+  ssl_certificate /etc/nginx/conf.d/company2.example.com.pem;
+  ssl_certificate_key /etc/nginx/conf.d/company2.example.com-key.pem;
+
+  location / {
+    default_type text/html;
+    return 200 "";
+  }
+}
+
+server {
+  server_name app.company3.example.com;
+
+  listen 443 ssl;
+  ssl_certificate /etc/nginx/conf.d/app.company3.example.com.pem;
+  ssl_certificate_key /etc/nginx/conf.d/app.company3.example.com-key.pem;
+
+  location / {
+    default_type text/html;
+    return 200 "";
   }
 }

--- a/.local/nginx/default.conf
+++ b/.local/nginx/default.conf
@@ -50,6 +50,8 @@ server {
   ssl_certificate /etc/nginx/conf.d/tesseralusercontent.example.com.pem;
   ssl_certificate_key /etc/nginx/conf.d/tesseralusercontent.example.com-key.pem;
 
+  resolver 127.0.0.11 valid=1s;
+
   location / {
     set $upstream http://s3:9090;
     proxy_pass $upstream;

--- a/.local/nginx/includes/vault.conf
+++ b/.local/nginx/includes/vault.conf
@@ -1,7 +1,7 @@
 resolver 127.0.0.11 valid=1s;
 
 location / {
-  set $upstream http://vault-ui:3002/;
+  set $upstream http://vault-ui:3002;
   proxy_pass $upstream;
 }
 

--- a/.local/nginx/includes/vault.conf
+++ b/.local/nginx/includes/vault.conf
@@ -1,47 +1,20 @@
-location / {
-  proxy_http_version 1.1;
-  proxy_next_upstream error timeout http_500 http_502 http_503 http_504;
-  proxy_read_timeout 10s;
-  proxy_send_timeout 10s;
-  proxy_set_header Connection "upgrade";
-  proxy_set_header Host $host;
-  proxy_set_header Upgrade $http_upgrade;
-  proxy_set_header X-Real-IP $remote_addr;
-  proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-  proxy_set_header X-Forwarded-Proto $scheme;
+resolver 127.0.0.11 valid=1s;
 
-  proxy_pass http://vault-ui:3002/;
+location / {
+  set $upstream http://vault-ui:3002/;
+  proxy_pass $upstream;
 }
 
-location ~ ^/(api/.*) {
-  proxy_http_version 1.1;
-  proxy_next_upstream error timeout http_500 http_502 http_503 http_504;
-  proxy_read_timeout 10s;
-  proxy_send_timeout 10s;
-  proxy_set_header Connection "upgrade";
-  proxy_set_header Host $host;
-  proxy_set_header Upgrade $http_upgrade;
-  proxy_set_header X-Real-IP $remote_addr;
-  proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-  proxy_set_header X-Forwarded-Proto $scheme;
+location /api {
   proxy_set_header X-Tesseral-Host $http_host;
 
-  resolver 127.0.0.11;
-  proxy_pass http://api:3001/$1;
+  set $upstream http://api:3001$request_uri;
+  proxy_pass $upstream;
 }
 
-location ~ ^/(.well-known/.*) {
-  proxy_http_version 1.1;
-  proxy_next_upstream error timeout http_500 http_502 http_503 http_504;
-  proxy_read_timeout 10s;
-  proxy_send_timeout 10s;
-  proxy_set_header Connection "upgrade";
-  proxy_set_header Host $host;
-  proxy_set_header Upgrade $http_upgrade;
-  proxy_set_header X-Real-IP $remote_addr;
-  proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-  proxy_set_header X-Forwarded-Proto $scheme;
+location /.well-known {
+  proxy_set_header X-Tesseral-Host $http_host;
 
-  resolver 127.0.0.11;
-  proxy_pass http://api:3001/$1;
+  set $upstream http://api:3001$request_uri;
+  proxy_pass $upstream;
 }


### PR DESCRIPTION
This PR makes changes only for local development. In particular, this PR changes how nginx configuration works in local dev:

1. All nginx server blocks that front other docker containers are configured with `resolver 127.0.0.11 valid=1s;` and do not directly `proxy_pass http://container;`, instead doing a `set $upstream http://container; proxy_pass $upstream;`. This has the effect of forcing nginx to do DNS lookups at HTTP request time, and of re-resolving container addresses with a 1-second TTL. This TTL-ing is necessary because if the proxied container is restarted, it may be come back on a different IP address.
2. Most of the parameters we were passing to `proxy_pass` are unnecessary. Simple is easier to fix down the line. IPv6 configuration also got the same treatment.
3. I reorganized the directives to always start with the `server_name`, because they tell you what you're looking at.

I can't find first-party documentation on the variable-related behavior in (1), but there many references to this behavior in the wild.