### PR TITLE
Return more meaningful errors for failed ValidateAPIKey requests

### DIFF
--- a/console/src/pages/organizations/api-keys/CreateAPIKeyButton.tsx
+++ b/console/src/pages/organizations/api-keys/CreateAPIKeyButton.tsx
@@ -27,6 +27,7 @@ import {
 import {
   Select,
   SelectContent,
+  SelectItem,
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
@@ -43,7 +44,6 @@ import {
   useMutation,
   useQuery,
 } from '@connectrpc/connect-query';
-import { SelectItem } from '@radix-ui/react-select';
 import { format } from 'date-fns';
 import { CalendarIcon, CirclePlus } from 'lucide-react';
 import React, { useState } from 'react';

--- a/internal/backend/store/api_keys.go
+++ b/internal/backend/store/api_keys.go
@@ -288,7 +288,7 @@ func (s *Store) AuthenticateAPIKey(ctx context.Context, req *backendv1.Authentic
 
 	secretTokenBytes, err := prettysecret.Parse(*qProject.ApiKeySecretTokenPrefix, req.SecretToken)
 	if err != nil {
-		return nil, apierror.NewInvalidArgumentError("malformed_api_key_secret_token", fmt.Errorf("parse secret token: %w", err))
+		return nil, apierror.NewUnauthenticatedApiKeyError("malformed_api_key_secret_token", fmt.Errorf("parse secret token: %w", err))
 	}
 	secretTokenSHA256 := sha256.Sum256(secretTokenBytes[:])
 
@@ -298,7 +298,7 @@ func (s *Store) AuthenticateAPIKey(ctx context.Context, req *backendv1.Authentic
 	})
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, apierror.NewInvalidArgumentError("invalid_api_key_secret_token", fmt.Errorf("get api key details: %w", err))
+			return nil, apierror.NewUnauthenticatedApiKeyError("invalid_api_key_secret_token", fmt.Errorf("get api key details: %w", err))
 		}
 
 		return nil, fmt.Errorf("get api key details: %w", err)

--- a/internal/backend/store/api_keys.go
+++ b/internal/backend/store/api_keys.go
@@ -31,7 +31,7 @@ func (s *Store) CreateAPIKey(ctx context.Context, req *backendv1.CreateAPIKeyReq
 
 	orgID, err := idformat.Organization.Parse(req.ApiKey.OrganizationId)
 	if err != nil {
-		return nil, apierror.NewInvalidArgumentError("invalid organization id", fmt.Errorf("parse organization id: %w", err))
+		return nil, apierror.NewInvalidArgumentError("invalid_organization_id", fmt.Errorf("parse organization id: %w", err))
 	}
 
 	if _, err := s.q.GetOrganizationByProjectIDAndID(ctx, queries.GetOrganizationByProjectIDAndIDParams{
@@ -39,7 +39,7 @@ func (s *Store) CreateAPIKey(ctx context.Context, req *backendv1.CreateAPIKeyReq
 		ProjectID: authn.ProjectID(ctx),
 	}); err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, apierror.NewNotFoundError("organization not found", fmt.Errorf("get organization: %w", err))
+			return nil, apierror.NewNotFoundError("organization_not_found", fmt.Errorf("get organization: %w", err))
 		}
 		return nil, fmt.Errorf("get organization: %w", err)
 	}
@@ -50,7 +50,7 @@ func (s *Store) CreateAPIKey(ctx context.Context, req *backendv1.CreateAPIKeyReq
 	}
 
 	if !qProject.ApiKeysEnabled {
-		return nil, apierror.NewPermissionDeniedError("api keys are not enabled for this project", fmt.Errorf("api keys not enabled for project"))
+		return nil, apierror.NewPermissionDeniedError("api_keys_not_enabled", fmt.Errorf("api keys not enabled for project"))
 	}
 
 	var secretTokenValue [35]byte
@@ -103,7 +103,7 @@ func (s *Store) DeleteAPIKey(ctx context.Context, req *backendv1.DeleteAPIKeyReq
 
 	apiKeyID, err := idformat.APIKey.Parse(req.Id)
 	if err != nil {
-		return nil, apierror.NewInvalidArgumentError("invalid api key id", fmt.Errorf("parse api key id: %w", err))
+		return nil, apierror.NewInvalidArgumentError("invalid_api_key_id", fmt.Errorf("parse api key id: %w", err))
 	}
 
 	qApiKey, err := q.GetAPIKeyByID(ctx, queries.GetAPIKeyByIDParams{
@@ -112,13 +112,13 @@ func (s *Store) DeleteAPIKey(ctx context.Context, req *backendv1.DeleteAPIKeyReq
 	})
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, apierror.NewNotFoundError("api key not found", fmt.Errorf("get api key: %w", err))
+			return nil, apierror.NewNotFoundError("api_key_not_found", fmt.Errorf("get api key: %w", err))
 		}
 		return nil, fmt.Errorf("get api key: %w", err)
 	}
 
 	if qApiKey.SecretTokenSha256 != nil {
-		return nil, apierror.NewFailedPreconditionError("api key must be revoked to be deleted", fmt.Errorf("api key mut be revoked to be deleted"))
+		return nil, apierror.NewFailedPreconditionError("api_key_not_revoked", fmt.Errorf("api key mut be revoked to be deleted"))
 	}
 
 	if err := q.DeleteAPIKey(ctx, queries.DeleteAPIKeyParams{
@@ -145,7 +145,7 @@ func (s *Store) GetAPIKey(ctx context.Context, req *backendv1.GetAPIKeyRequest) 
 
 	apiKeyID, err := idformat.APIKey.Parse(req.Id)
 	if err != nil {
-		return nil, apierror.NewInvalidArgumentError("invalid api key id", fmt.Errorf("parse api key id: %w", err))
+		return nil, apierror.NewInvalidArgumentError("invalid_api_key_id", fmt.Errorf("parse api key id: %w", err))
 	}
 
 	qAPIKey, err := q.GetAPIKeyByID(ctx, queries.GetAPIKeyByIDParams{
@@ -174,7 +174,7 @@ func (s *Store) ListAPIKeys(ctx context.Context, req *backendv1.ListAPIKeysReque
 
 	orgID, err := idformat.Organization.Parse(req.OrganizationId)
 	if err != nil {
-		return nil, apierror.NewInvalidArgumentError("invalid organization id", fmt.Errorf("parse organization id: %w", err))
+		return nil, apierror.NewInvalidArgumentError("invalid_organization_id", fmt.Errorf("parse organization id: %w", err))
 	}
 
 	var startID uuid.UUID
@@ -219,7 +219,7 @@ func (s *Store) RevokeAPIKey(ctx context.Context, req *backendv1.RevokeAPIKeyReq
 
 	apiKeyID, err := idformat.APIKey.Parse(req.Id)
 	if err != nil {
-		return nil, apierror.NewInvalidArgumentError("invalid api key id", fmt.Errorf("parse api key id: %w", err))
+		return nil, apierror.NewInvalidArgumentError("invalid_api_key_id", fmt.Errorf("parse api key id: %w", err))
 	}
 
 	if err := q.RevokeAPIKey(ctx, queries.RevokeAPIKeyParams{
@@ -245,7 +245,7 @@ func (s *Store) UpdateAPIKey(ctx context.Context, req *backendv1.UpdateAPIKeyReq
 
 	apiKeyID, err := idformat.APIKey.Parse(req.Id)
 	if err != nil {
-		return nil, apierror.NewInvalidArgumentError("invalid api key id", fmt.Errorf("parse api key id: %w", err))
+		return nil, apierror.NewInvalidArgumentError("invalid_api_key_id", fmt.Errorf("parse api key id: %w", err))
 	}
 
 	updatedApiKey, err := q.UpdateAPIKey(ctx, queries.UpdateAPIKeyParams{
@@ -279,16 +279,16 @@ func (s *Store) AuthenticateAPIKey(ctx context.Context, req *backendv1.Authentic
 	}
 
 	if !qProject.ApiKeysEnabled {
-		return nil, apierror.NewPermissionDeniedError("api keys are not enabled for this project", fmt.Errorf("api keys not enabled for project"))
+		return nil, apierror.NewFailedPreconditionError("api_keys_not_enabled", fmt.Errorf("api keys not enabled for project"))
 	}
 
 	if qProject.ApiKeySecretTokenPrefix == nil {
-		return nil, apierror.NewPermissionDeniedError("api key secret token prefix is not set for this project", fmt.Errorf("api key secret token prefix not set for project"))
+		return nil, apierror.NewFailedPreconditionError("no_api_key_secret_token_prefix", fmt.Errorf("api key secret token prefix not set for project"))
 	}
 
 	secretTokenBytes, err := prettysecret.Parse(*qProject.ApiKeySecretTokenPrefix, req.SecretToken)
 	if err != nil {
-		return nil, apierror.NewInvalidArgumentError("invalid secret token", fmt.Errorf("parse secret token: %w", err))
+		return nil, apierror.NewInvalidArgumentError("invalid_secret_token", fmt.Errorf("parse secret token: %w", err))
 	}
 	secretTokenSHA256 := sha256.Sum256(secretTokenBytes[:])
 
@@ -298,7 +298,7 @@ func (s *Store) AuthenticateAPIKey(ctx context.Context, req *backendv1.Authentic
 	})
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, apierror.NewNotFoundError("api key not found", fmt.Errorf("get api key details: %w", err))
+			return nil, apierror.NewNotFoundError("api_key_not_found", fmt.Errorf("get api key details: %w", err))
 		}
 
 		return nil, fmt.Errorf("get api key details: %w", err)

--- a/internal/common/apierror/errors.go
+++ b/internal/common/apierror/errors.go
@@ -9,9 +9,10 @@ var errAlreadyExists = "already_exists"
 var errFailedPrecondition = "failed_precondition"
 var errInvalidArgument = "invalid_argument"
 var errNotFound = "not_found"
+var errPasswordCompromised = "password_compromised"
 var errPermissionDenied = "permission_denied"
 var errUnauthenticated = "unauthenticated"
-var errPasswordCompromised = "password_compromised"
+var errUnauthenticatedApiKey = "unauthenticated_api_key"
 
 func NewAlreadyExistsError(description string, sourceError error) error {
 	apiErr := New(errAlreadyExists, sourceError)
@@ -90,6 +91,21 @@ func NewPermissionDeniedError(description string, sourceError error) error {
 
 func NewUnauthenticatedError(description string, sourceError error) error {
 	apiErr := New(errUnauthenticated, sourceError)
+
+	err := connect.NewError(connect.CodeUnauthenticated, apiErr)
+
+	// Add details to the connect error
+	if detail, detailErr := connect.NewErrorDetail(&commonv1.ErrorDetail{
+		Description: description,
+	}); detailErr == nil {
+		err.AddDetail(detail)
+	}
+
+	return err
+}
+
+func NewUnauthenticatedApiKeyError(description string, sourceError error) error {
+	apiErr := New(errUnauthenticatedApiKey, sourceError)
 
 	err := connect.NewError(connect.CodeUnauthenticated, apiErr)
 

--- a/internal/common/apierror/errors.go
+++ b/internal/common/apierror/errors.go
@@ -107,7 +107,7 @@ func NewUnauthenticatedError(description string, sourceError error) error {
 func NewUnauthenticatedApiKeyError(description string, sourceError error) error {
 	apiErr := New(errUnauthenticatedApiKey, sourceError)
 
-	err := connect.NewError(connect.CodeUnauthenticated, apiErr)
+	err := connect.NewError(connect.CodeInvalidArgument, apiErr)
 
 	// Add details to the connect error
 	if detail, detailErr := connect.NewErrorDetail(&commonv1.ErrorDetail{


### PR DESCRIPTION
This PR returns more meaningful responses from the ValidateAPIKey request when the API key is either malformed or otherwise invalid.

It also fixes a small import error with the Select menu for the `CreateAPIKeyButton` form.