### PR TITLE
Fix logout with bad token

### DIFF
--- a/console/src/components/ConsoleNavigation.tsx
+++ b/console/src/components/ConsoleNavigation.tsx
@@ -41,6 +41,7 @@ import {
 } from '@/gen/tesseral/backend/v1/backend-BackendService_connectquery';
 import { cn, titleCaseSlug } from '@/lib/utils';
 import { Input } from './ui/input';
+import { ConnectError } from '@connectrpc/connect';
 
 const ConsoleNavigation: FC = () => {
   const navigate = useNavigate();
@@ -50,7 +51,17 @@ const ConsoleNavigation: FC = () => {
   const { mutateAsync: logoutAsync } = useMutation(logout);
 
   const handleLogout = async () => {
-    await logoutAsync({});
+    try {
+      await logoutAsync({});
+    } catch (e) {
+      if (e instanceof ConnectError && e.metadata.has('set-cookie')) {
+        // OK. Even though the request failed, the credentials were cleared.
+      } else {
+        // Fail hard since credentials were not cleared by the server and the action
+        // must be retried.
+        throw e;
+      }
+    }
     toast.success('You have been logged out.');
     navigate('/login');
   };


### PR DESCRIPTION
When logging out with a bad access token, the Logout endpoint fails with a 401 unauthorized code. However, the access token and refresh token remain as cookies since they are not cleared by the Logout endpoint.

This can be easily seen in dev by logging in, re-bootstrapping, refreshing the console, and trying to logout. Nothing happens because the logout call is silently failing.

This PR ensures that bad access credentials are cleared from the cookies when presented to frontend API. It further updates the console logic to redirect when cookies have been cleared.