### PR TITLE
Improve local SES shutdown speed

### DIFF
--- a/.local/ses/Dockerfile
+++ b/.local/ses/Dockerfile
@@ -6,6 +6,22 @@ RUN mkdir -p /output
 
 RUN npm install aws-ses-v2-local -g
 
+RUN cat <<'EOF' > /bin/aws-ses-v2-local.sh
+#!/bin/bash
+#
+# Wrapper for SES Local emulator which monitors kill signals. Without this,
+# the `aws-ses-v2-local` CLI does not respond to Ctrl-C making shutdown times
+# longer when running in Docker.
+
+( exec aws-ses-v2-local $@ ) &
+pid=$!
+
+trap "kill -9 $pid" SIGINT SIGTERM
+
+wait $pid
+EOF
+RUN chmod +x /bin/aws-ses-v2-local.sh
+
 EXPOSE 8005
 
-ENTRYPOINT ["aws-ses-v2-local", "--port", "8005", "--host", "0.0.0.0"]
+ENTRYPOINT ["/bin/aws-ses-v2-local.sh", "--port", "8005", "--host", "0.0.0.0"]


### PR DESCRIPTION
When running the local dev environment and hitting Ctrl-C, the SES container takes several seconds to shutdown since the CLI does not listen/respond to SIGTERM.

This introduces a wrapper script to forcefully shutdown the CLI immediately so that `docker compose down` takes less than 1 second for all containers.