### PR TITLE
Update user details on login

### DIFF
--- a/internal/intermediate/store/exchange.go
+++ b/internal/intermediate/store/exchange.go
@@ -94,11 +94,11 @@ func (s *Store) ExchangeIntermediateSessionForSession(ctx context.Context, req *
 		qUser = &qNewUser
 	} else {
 		detailsUpdated =
-			derefOrEmpty(qIntermediateSession.GithubUserID) != derefOrEmpty(qUser.GithubUserID) ||
-				derefOrEmpty(qIntermediateSession.GoogleUserID) != derefOrEmpty(qUser.GoogleUserID) ||
-				derefOrEmpty(qIntermediateSession.MicrosoftUserID) != derefOrEmpty(qUser.MicrosoftUserID) ||
-				derefOrEmpty(qIntermediateSession.UserDisplayName) != derefOrEmpty(qUser.DisplayName) ||
-				derefOrEmpty(qIntermediateSession.ProfilePictureUrl) != derefOrEmpty(qUser.ProfilePictureUrl)
+			(qIntermediateSession.GithubUserID != nil && *qIntermediateSession.GithubUserID != derefOrEmpty(qUser.GithubUserID)) ||
+				(qIntermediateSession.GoogleUserID != nil && *qIntermediateSession.GoogleUserID != derefOrEmpty(qUser.GoogleUserID)) ||
+				(qIntermediateSession.MicrosoftUserID != nil && *qIntermediateSession.MicrosoftUserID != derefOrEmpty(qUser.MicrosoftUserID)) ||
+				(qIntermediateSession.UserDisplayName != nil && *qIntermediateSession.UserDisplayName != derefOrEmpty(qUser.DisplayName)) ||
+				(qIntermediateSession.ProfilePictureUrl != nil && *qIntermediateSession.ProfilePictureUrl != derefOrEmpty(qUser.ProfilePictureUrl))
 
 		if detailsUpdated {
 			slog.InfoContext(ctx, "update_user")

--- a/internal/intermediate/store/exchange.go
+++ b/internal/intermediate/store/exchange.go
@@ -68,7 +68,10 @@ func (s *Store) ExchangeIntermediateSessionForSession(ctx context.Context, req *
 		return nil, fmt.Errorf("match user: %w", err)
 	}
 
-	newUser := qUser == nil
+	var (
+		newUser        = qUser == nil
+		detailsUpdated = newUser
+	)
 
 	// if no matching user, create a new one
 	if qUser == nil {
@@ -81,6 +84,7 @@ func (s *Store) ExchangeIntermediateSessionForSession(ctx context.Context, req *
 			ProfilePictureUrl: qIntermediateSession.ProfilePictureUrl,
 			GoogleUserID:      qIntermediateSession.GoogleUserID,
 			MicrosoftUserID:   qIntermediateSession.MicrosoftUserID,
+			GithubUserID:      qIntermediateSession.GithubUserID,
 			PasswordBcrypt:    qIntermediateSession.NewUserPasswordBcrypt,
 		})
 		if err != nil {
@@ -88,12 +92,36 @@ func (s *Store) ExchangeIntermediateSessionForSession(ctx context.Context, req *
 		}
 
 		qUser = &qNewUser
+	} else {
+		detailsUpdated =
+			derefOrEmpty(qIntermediateSession.GithubUserID) != derefOrEmpty(qUser.GithubUserID) ||
+				derefOrEmpty(qIntermediateSession.GoogleUserID) != derefOrEmpty(qUser.GoogleUserID) ||
+				derefOrEmpty(qIntermediateSession.MicrosoftUserID) != derefOrEmpty(qUser.MicrosoftUserID) ||
+				derefOrEmpty(qIntermediateSession.UserDisplayName) != derefOrEmpty(qUser.DisplayName) ||
+				derefOrEmpty(qIntermediateSession.ProfilePictureUrl) != derefOrEmpty(qUser.ProfilePictureUrl)
+
+		if detailsUpdated {
+			slog.InfoContext(ctx, "update_user")
+			qUpdatedUser, err := q.UpdateUserDetails(ctx, queries.UpdateUserDetailsParams{
+				UserID:            qUser.ID,
+				GithubUserID:      qIntermediateSession.GithubUserID,
+				GoogleUserID:      qIntermediateSession.GoogleUserID,
+				MicrosoftUserID:   qIntermediateSession.MicrosoftUserID,
+				DisplayName:       qIntermediateSession.UserDisplayName,
+				ProfilePictureUrl: qIntermediateSession.ProfilePictureUrl,
+			})
+			if err != nil {
+				return nil, fmt.Errorf("update user: %w", err)
+			}
+			qUser = &qUpdatedUser
+		}
 	}
 
 	// if a passkey is registered on the intermediate session, copy it onto the
 	// user
 	if qIntermediateSession.PasskeyCredentialID != nil {
 		slog.InfoContext(ctx, "register_passkey")
+		detailsUpdated = true
 		if err := s.copyRegisteredPasskeySettings(ctx, q, qIntermediateSession, *qUser); err != nil {
 			return nil, fmt.Errorf("copy registered passkey settings: %w", err)
 		}
@@ -103,6 +131,7 @@ func (s *Store) ExchangeIntermediateSessionForSession(ctx context.Context, req *
 	// it onto the user
 	if qIntermediateSession.AuthenticatorAppSecretCiphertext != nil {
 		slog.InfoContext(ctx, "register_authenticator_app")
+		detailsUpdated = true
 		if err := s.copyRegisteredAuthenticatorAppSettings(ctx, q, qIntermediateSession, *qUser); err != nil {
 			return nil, fmt.Errorf("copy registered authenticator app settings: %w", err)
 		}
@@ -144,6 +173,7 @@ func (s *Store) ExchangeIntermediateSessionForSession(ctx context.Context, req *
 	if qUserInvite.ID != uuid.Nil {
 		slog.InfoContext(ctx, "upgrade_user_invite", "is_owner", qUserInvite.IsOwner)
 		if qUserInvite.IsOwner {
+			detailsUpdated = true
 			if _, err := q.UpdateUserIsOwner(ctx, queries.UpdateUserIsOwnerParams{
 				ID:      qUser.ID,
 				IsOwner: true,
@@ -179,7 +209,7 @@ func (s *Store) ExchangeIntermediateSessionForSession(ctx context.Context, req *
 		return nil, err
 	}
 
-	if qUser != nil {
+	if detailsUpdated {
 		// Send sync user event
 		if err := s.sendSyncUserEvent(ctx, *qUser); err != nil {
 			return nil, fmt.Errorf("send sync user event: %w", err)

--- a/sqlc/queries-intermediate.sql
+++ b/sqlc/queries-intermediate.sql
@@ -733,3 +733,18 @@ WHERE
     organization_id = $1
     AND github_user_id = $2;
 
+-- name: UpdateUserDetails :one
+UPDATE
+    users
+SET
+    update_time = now(),
+    github_user_id = coalesce(sqlc.narg (github_user_id), github_user_id),
+    google_user_id = coalesce(sqlc.narg (google_user_id), google_user_id),
+    microsoft_user_id = coalesce(sqlc.narg (microsoft_user_id), microsoft_user_id),
+    display_name = coalesce(sqlc.narg (display_name), display_name),
+    profile_picture_url = coalesce(sqlc.narg (profile_picture_url), profile_picture_url)
+WHERE
+    id = @user_id
+RETURNING
+    *;
+


### PR DESCRIPTION
When logging in with GitHub or some external IdP, any details captured on the intermediate session (like GitHub user ID, profile picture URL, etc) are not transferred to the user upon login.

Before, linking an existing account with a GitHub login would not populate the user's details like GitHub User ID:
<img width="1822" alt="Screenshot 2025-05-26 at 3 07 19 PM" src="https://github.com/user-attachments/assets/99a62d92-3737-4f16-bbf3-8d56702e0cbd" />

Now, user details are populated on login: 
<img width="1822" alt="Screenshot 2025-05-26 at 3 08 35 PM" src="https://github.com/user-attachments/assets/c57a2661-f424-4643-9cb9-bf2a8ea1cc0a" />

