### PR TITLE
Enable passkey deletion in Vault

### DIFF
--- a/vault-ui/src/pages/dashboard/UserSettingsPage.tsx
+++ b/vault-ui/src/pages/dashboard/UserSettingsPage.tsx
@@ -8,6 +8,7 @@ import {
   AlertDialog,
   AlertDialogCancel,
   AlertDialogContent,
+  AlertDialogDescription,
   AlertDialogFooter,
   AlertDialogHeader,
   AlertDialogTitle,
@@ -190,10 +191,10 @@ function DeletePasskeyButton({ passkeyId }: { passkeyId: string }) {
       <AlertDialogContent>
         <AlertDialogHeader>
           <AlertDialogTitle>Are you sure?</AlertDialogTitle>
-          <p>
+          <AlertDialogDescription>
             This action cannot be undone. The passkey will be permanently
             deleted.
-          </p>
+          </AlertDialogDescription>
         </AlertDialogHeader>
         <AlertDialogFooter>
           <AlertDialogCancel>Cancel</AlertDialogCancel>


### PR DESCRIPTION
Currently, the button does nothing. This PR hooks up the button to the existing RPC call.