### PR TITLE
chore: update golangci-lint config to v2 schema

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,3 +1,4 @@
+version: "2"
 issues:
   exclude-rules:
     - linters:


### PR DESCRIPTION
Recent versions of `golangci-lint` fail on `main` because the new schema requires the version to be specified in `.golangci.yml`:

```
% golangci-lint --version
golangci-lint has version 2.1.6 built with go1.24.2 from eabc2638 on 2025-05-04T15:41:19Z
% golangci-lint run
Error: can't load config: unsupported version of the configuration: "" See https://golangci-lint.run/product/migration-guide for migration instructions
Failed executing command with error: can't load config: unsupported version of the configuration: "" See https://golangci-lint.run/product/migration-guide for migration instructions
```

This PR adds a snippet that establishes the latest `golangci-lint` schema version. After the fix:

```
% golangci-lint run
cmd/api/main.go:71:12: undefined: sentry (typecheck)
	if err := sentry.Init(sentry.ClientOptions{
	          ^
cmd/openauthctl/migrate.go:26:34: undefined: migrate (typecheck)
func (a migrateArgs) migrate() (*migrate.Migrate, error) {
...
```