### PR TITLE
chore: fix most of staticcheck errors

### DIFF
--- a/cmd/openauthctl/bootstrap.go
+++ b/cmd/openauthctl/bootstrap.go
@@ -21,11 +21,11 @@ type bootstrapArgs struct {
 	VaultDomain            string `cli:"--vault-domain"`
 }
 
-func (_ bootstrapArgs) Description() string {
+func (bootstrapArgs) Description() string {
 	return "Bootstrap a Tesseral database"
 }
 
-func (_ bootstrapArgs) ExtendedDescription() string {
+func (bootstrapArgs) ExtendedDescription() string {
 	return strings.TrimSpace(`
 Bootstrap a Tesseral database.
 

--- a/cmd/openauthctl/main.go
+++ b/cmd/openauthctl/main.go
@@ -14,6 +14,6 @@ func main() {
 type args struct {
 }
 
-func (_ args) ExtendedDescription() string {
+func (args) ExtendedDescription() string {
 	return "Control the openauth database"
 }

--- a/cmd/openauthctl/migrate.go
+++ b/cmd/openauthctl/migrate.go
@@ -19,7 +19,7 @@ type migrateArgs struct {
 	Verbose  bool   `cli:"-v,--verbose"`
 }
 
-func (_ migrateArgs) ExtendedDescription() string {
+func (migrateArgs) ExtendedDescription() string {
 	return "Run openauth database migrations"
 }
 

--- a/internal/backend/store/project_ui_settings.go
+++ b/internal/backend/store/project_ui_settings.go
@@ -31,14 +31,12 @@ func (s *Store) GetProjectUISettings(ctx context.Context, req *backendv1.GetProj
 	}
 
 	logoKey := fmt.Sprintf("vault-ui-settings-v1/%s/logo", idformat.Project.Format(projectID))
-	logoURL := fmt.Sprintf("%s/%s", s.userContentBaseUrl, logoKey)
 	logoExists, err := s.getUserContentFileExists(ctx, logoKey)
 	if err != nil {
 		return nil, fmt.Errorf("failed to check if logo file exists: %w", err)
 	}
-	if !logoExists {
-		logoURL = ""
-	} else {
+	logoURL := ""
+	if logoExists {
 		logoURL, err = s.buildPresignedGetUrlForFile(ctx, logoKey)
 		if err != nil {
 			return nil, fmt.Errorf("failed to build presigned URL for logo file: %w", err)
@@ -46,14 +44,12 @@ func (s *Store) GetProjectUISettings(ctx context.Context, req *backendv1.GetProj
 	}
 
 	darkModeLogoKey := fmt.Sprintf("vault-ui-settings-v1/%s/logo-dark", idformat.Project.Format(projectID))
-	darkModeLogoURL := fmt.Sprintf("%s/%s", s.userContentBaseUrl, darkModeLogoKey)
 	darkModeLogoExists, err := s.getUserContentFileExists(ctx, darkModeLogoKey)
 	if err != nil {
 		return nil, fmt.Errorf("failed to check if dark mode logo file exists: %w", err)
 	}
-	if !darkModeLogoExists {
-		darkModeLogoURL = ""
-	} else {
+	darkModeLogoURL := ""
+	if darkModeLogoExists {
 		darkModeLogoURL, err = s.buildPresignedGetUrlForFile(ctx, darkModeLogoKey)
 		if err != nil {
 			return nil, fmt.Errorf("failed to build presigned URL for dark mode logo file: %w", err)

--- a/internal/intermediate/store/settings.go
+++ b/internal/intermediate/store/settings.go
@@ -39,14 +39,12 @@ func (s *Store) GetSettings(ctx context.Context, req *intermediatev1.GetSettings
 	}
 
 	logoKey := fmt.Sprintf("vault-ui-settings-v1/%s/logo", idformat.Project.Format(projectID))
-	logoURL := fmt.Sprintf("%s/%s", s.userContentBaseUrl, logoKey)
 	logoExists, err := s.getUserContentFileExists(ctx, logoKey)
 	if err != nil {
 		return nil, fmt.Errorf("failed to check if logo file exists: %w", err)
 	}
-	if !logoExists {
-		logoURL = ""
-	} else {
+	logoURL := ""
+	if logoExists {
 		logoURL, err = s.buildPresignedGetUrlForFile(ctx, logoKey)
 		if err != nil {
 			return nil, fmt.Errorf("failed to build presigned URL for logo file: %w", err)
@@ -54,14 +52,12 @@ func (s *Store) GetSettings(ctx context.Context, req *intermediatev1.GetSettings
 	}
 
 	darkModeLogoKey := fmt.Sprintf("vault-ui-settings-v1/%s/logo-dark", idformat.Project.Format(projectID))
-	darkModeLogoURL := fmt.Sprintf("%s/%s", s.userContentBaseUrl, darkModeLogoKey)
 	darkModeLogoExists, err := s.getUserContentFileExists(ctx, darkModeLogoKey)
 	if err != nil {
 		return nil, fmt.Errorf("failed to check if dark mode logo file exists: %w", err)
 	}
-	if !darkModeLogoExists {
-		darkModeLogoURL = ""
-	} else {
+	darkModeLogoURL := ""
+	if darkModeLogoExists {
 		darkModeLogoURL, err = s.buildPresignedGetUrlForFile(ctx, darkModeLogoKey)
 		if err != nil {
 			return nil, fmt.Errorf("failed to build presigned URL for dark mode logo file: %w", err)

--- a/internal/saml/internal/saml/dsig/dsig.go
+++ b/internal/saml/internal/saml/dsig/dsig.go
@@ -41,7 +41,7 @@ type BadCertificateError struct {
 }
 
 func (e BadCertificateError) Error() string {
-	return fmt.Sprintf("dsig: bad certificate on response")
+	return "dsig: bad certificate on response"
 }
 
 func Verify(cert *x509.Certificate, data []byte) ([]byte, error) {

--- a/internal/saml/internal/saml/dsig/path.go
+++ b/internal/saml/internal/saml/dsig/path.go
@@ -59,9 +59,7 @@ func onlyPathHoistNamesInternal(p path, s stack.Stack, n uxml.Node) (uxml.Node, 
 
 	if len(p) == 1 {
 		var attrs []uxml.Attr
-		for _, a := range n.Element.Attrs {
-			attrs = append(attrs, a)
-		}
+		attrs = append(attrs, n.Element.Attrs...)
 		for k, v := range s.GetAll() {
 			if k == "" {
 				attrs = append(attrs, uxml.Attr{


### PR DESCRIPTION
This PR fixes most of `staticcheck` errors reported by the linter after #442.

**Note:** it seems that variables like `logoURL`, `darkModeLogoURL`, etc. aren't really used. They're either set to blank or populated by `buildPresignedGetUrlForFile`. The original variables are always replaced by either option. Wandering if the default behavior is to have them populated with the `fmt.Sprintf` as opposed to being empty. In that case the current logic isn't working as expected and we would expect something like:

```go
// Populate logoURL with the format specified here:
logoURL := fmt.Sprintf("%s/%s", s.userContentBaseUrl, logoKey)
logoExists, err := s.getUserContentFileExists(ctx, logoKey)
if err != nil {
    return nil, fmt.Errorf("failed to check if logo file exists: %w", err)
}

// If logoExists is true then return presigned URL:
if logoExists {
    logoURL, err = s.buildPresignedGetUrlForFile(ctx, logoKey)
    ...
    return
}
// If logoExists is false then logoURL contains the fmt.Sprintf specified in the initial line...
```