### PR TITLE
chore: precompile API key secret token prefix regex

### DIFF
--- a/internal/backend/store/projects.go
+++ b/internal/backend/store/projects.go
@@ -21,6 +21,11 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
+var (
+	// apiKeySecretTokenPrefixRegex is a regex that matches valid API key secret token prefixes:
+	apiKeySecretTokenPrefixRegex = regexp.MustCompile(`^[a-z0-9_]+$`)
+)
+
 func (s *Store) GetProject(ctx context.Context, req *backendv1.GetProjectRequest) (*backendv1.GetProjectResponse, error) {
 	_, q, _, rollback, err := s.tx(ctx)
 	if err != nil {
@@ -244,7 +249,7 @@ func (s *Store) UpdateProject(ctx context.Context, req *backendv1.UpdateProjectR
 			return nil, apierror.NewFailedPreconditionError("api key secret token prefix must be no longer than 64 characters", fmt.Errorf("api key secret token prefix too long: %s", *req.Project.ApiKeySecretTokenPrefix))
 		}
 
-		if !regexp.MustCompile(`^[a-z0-9_]+$`).MatchString(*req.Project.ApiKeySecretTokenPrefix) {
+		if !apiKeySecretTokenPrefixRegex.MatchString(*req.Project.ApiKeySecretTokenPrefix) {
 			return nil, apierror.NewFailedPreconditionError("api key secret token prefix must contain only lowercase letters, numbers, and underscores", fmt.Errorf("api key secret token prefix contains invalid characters: %s", *req.Project.ApiKeySecretTokenPrefix))
 		}
 

--- a/internal/backend/store/projects.go
+++ b/internal/backend/store/projects.go
@@ -21,10 +21,7 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
-var (
-	// apiKeySecretTokenPrefixRegex is a regex that matches valid API key secret token prefixes:
-	apiKeySecretTokenPrefixRegex = regexp.MustCompile(`^[a-z0-9_]+$`)
-)
+var apiKeySecretTokenPrefixRegex = regexp.MustCompile(`^[a-z0-9_]+$`)
 
 func (s *Store) GetProject(ctx context.Context, req *backendv1.GetProjectRequest) (*backendv1.GetProjectResponse, error) {
 	_, q, _, rollback, err := s.tx(ctx)


### PR DESCRIPTION
Just a general good practice to save a few cycles and a pattern that's already used in other parts of the code:

```go
% grep -r "regexp.Must" .
./internal/scim/service/service.go:	filterEmailPat = regexp.MustCompile(`userName eq "(.*)"`)
./internal/backend/store/rbac_policies.go:var actionPattern = regexp.MustCompile(`^[a-z0-9_]+\.[a-z0-9_]+\.[a-z0-9_]+`)
./internal/backend/store/projects.go:	apiKeySecretTokenPrefixRegex = regexp.MustCompile(`^[a-z0-9_]+$`)
./internal/emailaddr/emailaddr.go:var pat = regexp.MustCompile(`^[a-zA-Z0-9_.\-\\#+]+@([a-zA-Z0-9_.-]+)$`)
```