### PR TITLE
style: update Go test names to match the standard

### DIFF
--- a/internal/hibp/client_test.go
+++ b/internal/hibp/client_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 )
 
-func ExampleClient_Pwned() {
+func TestExampleClientPwned(t *testing.T) {
 	c := Client{HTTPClient: http.DefaultClient}
 	randomPassword := strconv.FormatFloat(rand.Float64(), 'f', -1, 64)
 	fmt.Println(c.Pwned(context.Background(), "letmein"))
@@ -66,6 +66,7 @@ func TestCheckLineMatch(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			got, err := checkLineMatch(tt.sha1HexSuffix, tt.line)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("checkLineMatch() error = %v, wantErr %v", err, tt.wantErr)

--- a/internal/intermediate/store/exchange_test.go
+++ b/internal/intermediate/store/exchange_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/tesseral-labs/tesseral/internal/intermediate/store/queries"
 )
 
-func TestStore_validateAuthRequirementsSatisfiedInner(t *testing.T) {
+func TestStoreValidateAuthRequirementsSatisfiedInner(t *testing.T) {
 	testCases := []struct {
 		name                 string
 		qIntermediateSession queries.IntermediateSession

--- a/internal/prettysecret/prettysecret_test.go
+++ b/internal/prettysecret/prettysecret_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/tesseral-labs/tesseral/internal/prettysecret"
 )
 
-func TestFormat_Parse_Errors(t *testing.T) {
+func TestFormatParseErrors(t *testing.T) {
 	format := func() (string, int) {
 		prefix := "test_"
 		length := prettysecret.SecretLen(prefix)
@@ -57,7 +57,7 @@ func TestFormat_Parse_Errors(t *testing.T) {
 	}
 }
 
-func TestFormat_Parse_RoundTrip(t *testing.T) {
+func TestFormatParseRoundTrip(t *testing.T) {
 	testCases := []struct {
 		Name   string
 		Secret [35]byte

--- a/internal/saml/internal/saml/validate_test.go
+++ b/internal/saml/internal/saml/validate_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/tesseral-labs/tesseral/internal/saml/internal/saml"
 )
 
-func TestValidate_KnownGoodAssertions(t *testing.T) {
+func TestValidateKnownGoodAssertions(t *testing.T) {
 	entries, err := os.ReadDir("testdata/assertions")
 	assert.NoError(t, err)
 
@@ -26,7 +26,7 @@ func TestValidate_KnownGoodAssertions(t *testing.T) {
 	}
 }
 
-func TestValidate_GoodAssertionData(t *testing.T) {
+func TestValidateGoodAssertionData(t *testing.T) {
 	res, err := validateFromDir("testdata/assertions/okta")
 	require.NoError(t, err)
 
@@ -37,7 +37,7 @@ func TestValidate_GoodAssertionData(t *testing.T) {
 	assert.Equal(t, map[string]string{}, res.SubjectAttributes)
 }
 
-func TestValidate_UnsignedAssertion(t *testing.T) {
+func TestValidateUnsignedAssertion(t *testing.T) {
 	// modified from okta, but assertion.xml has the signature stripped
 	_, err := validateFromDir("testdata/bad-assertions/unsigned-assertion")
 	var validateError *saml.ValidateError
@@ -48,7 +48,7 @@ func TestValidate_UnsignedAssertion(t *testing.T) {
 	require.True(t, validateError.UnsignedAssertion)
 }
 
-func TestValidate_BadIDPEntityID(t *testing.T) {
+func TestValidateBadIDPEntityID(t *testing.T) {
 	// modified from okta, but metadata.xml has a different idp entity id
 	_, err := validateFromDir("testdata/bad-assertions/bad-idp-entity-id")
 	var validateError *saml.ValidateError
@@ -60,7 +60,7 @@ func TestValidate_BadIDPEntityID(t *testing.T) {
 	assert.Equal(t, "http://www.okta.com/exkdoocxa1VmjpXmX697", *validateError.BadIDPEntityID)
 }
 
-func TestValidate_BadSPEntityID(t *testing.T) {
+func TestValidateBadSPEntityID(t *testing.T) {
 	// modified from okta, but params.json has a different sp entity id
 	_, err := validateFromDir("testdata/bad-assertions/bad-sp-entity-id")
 	var validateError *saml.ValidateError
@@ -72,7 +72,7 @@ func TestValidate_BadSPEntityID(t *testing.T) {
 	assert.Equal(t, "http://localhost:8080", *validateError.BadSPEntityID)
 }
 
-func TestValidate_BadSignatureAlgorithm(t *testing.T) {
+func TestValidateBadSignatureAlgorithm(t *testing.T) {
 	// modified from okta, but assertion.xml has a modified signature algorithm
 	_, err := validateFromDir("testdata/bad-assertions/bad-signature-algorithm")
 	var validateError *saml.ValidateError
@@ -84,7 +84,7 @@ func TestValidate_BadSignatureAlgorithm(t *testing.T) {
 	assert.Equal(t, "BAD_SIGNATURE_ALGORITHM", *validateError.BadSignatureAlgorithm)
 }
 
-func TestValidate_BadDigestAlgorithm(t *testing.T) {
+func TestValidateBadDigestAlgorithm(t *testing.T) {
 	// modified from okta, but assertion.xml has a modified digest algorithm
 	_, err := validateFromDir("testdata/bad-assertions/bad-digest-algorithm")
 	var validateError *saml.ValidateError
@@ -96,7 +96,7 @@ func TestValidate_BadDigestAlgorithm(t *testing.T) {
 	assert.Equal(t, "BAD_DIGEST_ALGORITHM", *validateError.BadDigestAlgorithm)
 }
 
-func TestValidate_BadCertificate(t *testing.T) {
+func TestValidateBadCertificate(t *testing.T) {
 	// modified from okta, but metadata.xml has a modified certificate
 	_, err := validateFromDir("testdata/bad-assertions/bad-certificate")
 	var validateError *saml.ValidateError
@@ -107,7 +107,7 @@ func TestValidate_BadCertificate(t *testing.T) {
 	require.NotEmpty(t, validateError.BadCertificate)
 }
 
-func TestValidate_NoCertificate(t *testing.T) {
+func TestValidateNoCertificate(t *testing.T) {
 	// modified from okta, but no KeyInfo
 	_, err := validateFromDir("testdata/bad-assertions/no-certificate")
 	var validateError *saml.ValidateError
@@ -118,7 +118,7 @@ func TestValidate_NoCertificate(t *testing.T) {
 	require.NotEmpty(t, validateError.UnsignedAssertion)
 }
 
-func TestValidate_BadAssertionUTF8(t *testing.T) {
+func TestValidateBadAssertionUTF8(t *testing.T) {
 	// modified from okta, but assertion.xml is just \x00 (and a newline)
 	_, err := validateFromDir("testdata/bad-assertions/bad-assertion-utf8")
 	var validateError *saml.ValidateError

--- a/internal/totp/totp_test.go
+++ b/internal/totp/totp_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/tesseral-labs/tesseral/internal/totp"
 )
 
-func TestKey_Validate(t *testing.T) {
+func TestKeyValidate(t *testing.T) {
 	// https://datatracker.ietf.org/doc/html/rfc6238#appendix-B
 	k := totp.Key{Secret: []byte("12345678901234567890")}
 

--- a/internal/ujwt/ujwt_test.go
+++ b/internal/ujwt/ujwt_test.go
@@ -133,7 +133,7 @@ func TestClaims(t *testing.T) {
 	}
 }
 
-func TestClaims_invalid(t *testing.T) {
+func TestClaimsInvalid(t *testing.T) {
 	tests := []struct {
 		name  string
 		token string


### PR DESCRIPTION
Changed all tests to mixed caps, no underscores and renamed `ExampleClient_Pwned`.