### PR TITLE
Fix email input in login page

### DIFF
--- a/console/src/pages/login/LoginPage.tsx
+++ b/console/src/pages/login/LoginPage.tsx
@@ -237,7 +237,11 @@ function LoginPageContents() {
                   <FormItem>
                     <FormLabel>Email</FormLabel>
                     <FormControl>
-                      <Input placeholder="john.doe@example.com" {...field} />
+                      <Input
+                        type="email"
+                        placeholder="john.doe@example.com"
+                        {...field}
+                      />
                     </FormControl>
                     <FormMessage />
                   </FormItem>

--- a/vault-ui/src/pages/login/LoginPage.tsx
+++ b/vault-ui/src/pages/login/LoginPage.tsx
@@ -261,7 +261,11 @@ function LoginPageContents() {
                   <FormItem>
                     <FormLabel>Email</FormLabel>
                     <FormControl>
-                      <Input placeholder="john.doe@example.com" {...field} />
+                      <Input
+                        type="email"
+                        placeholder="john.doe@example.com"
+                        {...field}
+                      />
                     </FormControl>
                     <FormMessage />
                   </FormItem>


### PR DESCRIPTION
The email input field was missing `type="email"` which led mobile browsers to automatically capitalize the first letter of the email address. This in turn led to errors logging in because the users' emails are case-sensitive. This change ensures that the input field is treated as an email input, preventing the issue.

Confirmed fix via iOS Simulator.