### PR TITLE
Match on GithubUserID during exchange

### DIFF
--- a/internal/intermediate/store/exchange.go
+++ b/internal/intermediate/store/exchange.go
@@ -355,6 +355,14 @@ func (s *Store) matchUser(ctx context.Context, q *queries.Queries, qOrg queries.
 		return qUser, nil
 	}
 
+	qUser, err = s.matchGithubUser(ctx, q, qOrg, qIntermediateSession)
+	if err != nil {
+		return nil, fmt.Errorf("match github user: %w", err)
+	}
+	if qUser != nil {
+		return qUser, nil
+	}
+
 	qUser, err = s.matchEmailUser(ctx, q, qOrg, qIntermediateSession)
 	if err != nil {
 		return nil, fmt.Errorf("match email user: %w", err)
@@ -399,6 +407,25 @@ func (s *Store) matchMicrosoftUser(ctx context.Context, q *queries.Queries, qOrg
 			return nil, nil
 		}
 		return nil, fmt.Errorf("get organization user by microsoft user id: %w", err)
+	}
+
+	return &qUser, nil
+}
+
+func (s *Store) matchGithubUser(ctx context.Context, q *queries.Queries, qOrg queries.Organization, qIntermediateSession queries.IntermediateSession) (*queries.User, error) {
+	if qIntermediateSession.GithubUserID == nil {
+		return nil, nil
+	}
+
+	qUser, err := q.GetOrganizationUserByGithubUserID(ctx, queries.GetOrganizationUserByGithubUserIDParams{
+		OrganizationID: qOrg.ID,
+		GithubUserID:   qIntermediateSession.GithubUserID,
+	})
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("get organization user by github user id: %w", err)
 	}
 
 	return &qUser, nil


### PR DESCRIPTION
During the process of exchanging an Intermediate Session for a full Session, we perform a matching step to determine if a user already exists with the same credential (Google User ID, Microsoft User ID, email, etc.).

Currently, we're not including GitHub User ID in this matching step, which means GitHub logins will always fall back to email when determining if a user should be created or not.

This is less than ideal for a number of reasons:
- It strays from the established exchange flow for other OAuth providers
- If a user changes their primary GitHub email address, they'll no longer be able to create a session for their existing user

---

This PR adds GitHub User ID matching to the exchange step to resolve the above issues.