### PR TITLE
Allow editing of RBAC actions

### DIFF
--- a/internal/backend/store/queries/queries-backend.sql.go
+++ b/internal/backend/store/queries/queries-backend.sql.go
@@ -3665,7 +3665,8 @@ const upsertAction = `-- name: UpsertAction :exec
 INSERT INTO actions (id, project_id, name, description)
     VALUES ($1, $2, $3, $4)
 ON CONFLICT (project_id, name)
-    DO NOTHING
+    DO UPDATE SET
+        description = excluded.description
 `
 
 type UpsertActionParams struct {

--- a/sqlc/queries-backend.sql
+++ b/sqlc/queries-backend.sql
@@ -859,7 +859,8 @@ WHERE
 INSERT INTO actions (id, project_id, name, description)
     VALUES ($1, $2, $3, $4)
 ON CONFLICT (project_id, name)
-    DO NOTHING;
+    DO UPDATE SET
+        description = excluded.description;
 
 -- name: DeleteActionsByNameNotInList :many
 DELETE FROM actions


### PR DESCRIPTION
Currently, once an action is added to the RBAC policy, its description is effectively permanent.

The way that the current `UpsertAction` query works, it simply ignores description changes when performing the Upsert.

---

This PR updates the `UpsertAction` query in the backend service to update the description on conflicts, allowing for editing actions from the Console and API.