### PR TITLE
Log in with Password: Only match users with `password_bcrypt`

### DIFF
--- a/internal/intermediate/store/queries/queries-intermediate.sql.go
+++ b/internal/intermediate/store/queries/queries-intermediate.sql.go
@@ -1547,6 +1547,7 @@ FROM
     JOIN organizations ON users.organization_id = organizations.id
 WHERE
     users.email = $1
+    AND users.password_bcrypt IS NOT NULL
     AND organizations.project_id = $2
     AND organizations.log_in_with_password = TRUE
     AND NOT organizations.logins_disabled

--- a/sqlc/queries-intermediate.sql
+++ b/sqlc/queries-intermediate.sql
@@ -313,6 +313,7 @@ FROM
     JOIN organizations ON users.organization_id = organizations.id
 WHERE
     users.email = $1
+    AND users.password_bcrypt IS NOT NULL
     AND organizations.project_id = $2
     AND organizations.log_in_with_password = TRUE
     AND NOT organizations.logins_disabled;


### PR DESCRIPTION
If a Project has only "Log in with Password" enabled and an end user inputs an email/password pair matching a single user, but that user has no `password_bcrypt`, then the user receives an error about no password being registered.

This PR instead has our behavior be to fail to find a matching user for the flow, and to fall back to the Log in with Email flow.