### PR TITLE
[OPEN-452] [OPEN-453] Fix authenticator app UI padding and error state

### DIFF
--- a/internal/common/apierror/errors.go
+++ b/internal/common/apierror/errors.go
@@ -15,6 +15,7 @@ var errPasswordCompromised = "password_compromised"
 var errPermissionDenied = "permission_denied"
 var errUnauthenticated = "unauthenticated"
 var errUnauthenticatedApiKey = "unauthenticated_api_key"
+var errIncorrectTOTPCode = "incorrect_totp_code"
 
 func NewAlreadyExistsError(description string, sourceError error) error {
 	apiErr := New(errAlreadyExists, sourceError)
@@ -153,6 +154,21 @@ func NewPasswordCompromisedError(description string, sourceError error) error {
 	apiErr := New(errPasswordCompromised, sourceError)
 
 	err := connect.NewError(connect.CodeFailedPrecondition, apiErr)
+
+	// Add details to the connect error
+	if detail, detailErr := connect.NewErrorDetail(&commonv1.ErrorDetail{
+		Description: description,
+	}); detailErr == nil {
+		err.AddDetail(detail)
+	}
+
+	return err
+}
+
+func NewInvalidTOTPCodeError(description string, sourceError error) error {
+	apiErr := New(errIncorrectTOTPCode, sourceError)
+
+	err := connect.NewError(connect.CodeInvalidArgument, apiErr)
 
 	// Add details to the connect error
 	if detail, detailErr := connect.NewErrorDetail(&commonv1.ErrorDetail{

--- a/internal/frontend/store/authenticator_apps.go
+++ b/internal/frontend/store/authenticator_apps.go
@@ -79,7 +79,7 @@ func (s *Store) RegisterAuthenticatorApp(ctx context.Context, req *frontendv1.Re
 
 	key := totp.Key{Secret: secret}
 	if err := key.Validate(time.Now(), req.TotpCode); err != nil {
-		return nil, apierror.NewInvalidArgumentError("invalid totp code", err)
+		return nil, apierror.NewInvalidTOTPCodeError("incorrect totp code", fmt.Errorf("validate totp code: %w", err))
 	}
 
 	var recoveryCodes []string


### PR DESCRIPTION
This PR improves the UX around authenticator app registration in the Vault. Spacing is fixed, a clear error state for bad TOTP codes, a success toast on completion of the flow, and reloading state after registering.

![screenshot-2025-06-16-15-03-16](https://github.com/user-attachments/assets/955a7dda-cbfa-44be-a86e-598a8090ba4f)
![screenshot-2025-06-16-15-16-17](https://github.com/user-attachments/assets/2cb7dcae-b2ba-4b1f-97a2-0f5e7c95d3fe)
