### PR TITLE
backend: populate ActorConsoleSessionID in logAuditEvent

### DIFF
--- a/internal/backend/store/log_audit_event.go
+++ b/internal/backend/store/log_audit_event.go
@@ -63,7 +63,7 @@ func (s *Store) logAuditEvent(ctx context.Context, q *queries.Queries, data logA
 		if err != nil {
 			return queries.AuditLogEvent{}, fmt.Errorf("parse dogfood session project id: %w", err)
 		}
-		qEventParams.ActorSessionID = (*uuid.UUID)(&dogfoodSessionUUID)
+		qEventParams.ActorConsoleSessionID = (*uuid.UUID)(&dogfoodSessionUUID)
 	}
 
 	qEvent, err := q.CreateAuditLogEvent(ctx, qEventParams)


### PR DESCRIPTION
Activity in the backend API associated with a Console session should populate the "console session" actor metadata, not the "session" actor metadata.