### PR TITLE
Resolve issues with some list queries not selecting properly

### DIFF
--- a/internal/backend/store/queries/queries-backend.sql.go
+++ b/internal/backend/store/queries/queries-backend.sql.go
@@ -130,7 +130,7 @@ WHERE
         OR $11 IS NULL)
     AND (resource_id = $12
         OR $12 IS NULL)
-    AND id <= $13
+    AND id < $13
 ORDER BY
     id DESC
 LIMIT $1

--- a/internal/backend/store/queries/queries-backend.sql.go
+++ b/internal/backend/store/queries/queries-backend.sql.go
@@ -2277,7 +2277,7 @@ FROM
 WHERE
     api_key_role_assignments.api_key_id = $1
     AND organization.project_id = $2
-    AND api_key_role_assignments.id > $3
+    AND api_key_role_assignments.id >= $3
 ORDER BY
     api_key_role_assignments.id
 LIMIT $4
@@ -2329,7 +2329,7 @@ FROM
 WHERE
     organization.id = $1
     AND organization.project_id = $2
-    AND api_keys.id > $3
+    AND api_keys.id >= $3
 ORDER BY
     api_keys.id
 LIMIT $4
@@ -2471,7 +2471,7 @@ FROM
     organizations
 WHERE
     project_id = $1
-    AND id > $2
+    AND id >= $2
 ORDER BY
     id
 LIMIT $3

--- a/internal/backend/store/queries/queries-backend.sql.go
+++ b/internal/backend/store/queries/queries-backend.sql.go
@@ -130,7 +130,7 @@ WHERE
         OR $11 IS NULL)
     AND (resource_id = $12
         OR $12 IS NULL)
-    AND id < $13
+    AND id <= $13
 ORDER BY
     id DESC
 LIMIT $1

--- a/internal/frontend/store/queries/queries-frontend.sql.go
+++ b/internal/frontend/store/queries/queries-frontend.sql.go
@@ -1628,7 +1628,7 @@ WHERE
         OR $6 IS NULL)
     AND (actor_user_id = $7
         OR $7 IS NULL)
-    AND id < $8
+    AND id <= $8
 ORDER BY
     id DESC
 LIMIT $1

--- a/internal/frontend/store/queries/queries-frontend.sql.go
+++ b/internal/frontend/store/queries/queries-frontend.sql.go
@@ -1480,7 +1480,7 @@ FROM
 WHERE
     api_key_role_assignments.api_key_id = $1
     AND api_keys.organization_id = $2
-    AND api_key_role_assignments.id > $3
+    AND api_key_role_assignments.id >= $3
 ORDER BY
     api_key_role_assignments.id
 LIMIT $4

--- a/internal/frontend/store/queries/queries-frontend.sql.go
+++ b/internal/frontend/store/queries/queries-frontend.sql.go
@@ -1530,7 +1530,7 @@ FROM
     api_keys
 WHERE
     organization_id = $1
-    AND id > $2
+    AND id >= $2
 ORDER BY
     id
 LIMIT $3
@@ -1628,7 +1628,7 @@ WHERE
         OR $6 IS NULL)
     AND (actor_user_id = $7
         OR $7 IS NULL)
-    AND id <= $8
+    AND id < $8
 ORDER BY
     id DESC
 LIMIT $1

--- a/sqlc/queries-backend.sql
+++ b/sqlc/queries-backend.sql
@@ -1204,7 +1204,7 @@ WHERE
         OR @resource_type IS NULL)
     AND (resource_id = @resource_id
         OR @resource_id IS NULL)
-    AND id < @id
+    AND id <= @id
 ORDER BY
     id DESC
 LIMIT $1;

--- a/sqlc/queries-backend.sql
+++ b/sqlc/queries-backend.sql
@@ -1204,7 +1204,7 @@ WHERE
         OR @resource_type IS NULL)
     AND (resource_id = @resource_id
         OR @resource_id IS NULL)
-    AND id <= @id
+    AND id < @id
 ORDER BY
     id DESC
 LIMIT $1;

--- a/sqlc/queries-backend.sql
+++ b/sqlc/queries-backend.sql
@@ -44,7 +44,7 @@ FROM
     organizations
 WHERE
     project_id = $1
-    AND id > $2
+    AND id >= $2
 ORDER BY
     id
 LIMIT $3;
@@ -1053,7 +1053,7 @@ FROM
 WHERE
     organization.id = $1
     AND organization.project_id = $2
-    AND api_keys.id > $3
+    AND api_keys.id >= $3
 ORDER BY
     api_keys.id
 LIMIT $4;
@@ -1110,7 +1110,7 @@ FROM
 WHERE
     api_key_role_assignments.api_key_id = $1
     AND organization.project_id = $2
-    AND api_key_role_assignments.id > $3
+    AND api_key_role_assignments.id >= $3
 ORDER BY
     api_key_role_assignments.id
 LIMIT $4;

--- a/sqlc/queries-frontend.sql
+++ b/sqlc/queries-frontend.sql
@@ -680,7 +680,7 @@ FROM
 WHERE
     api_key_role_assignments.api_key_id = $1
     AND api_keys.organization_id = $2
-    AND api_key_role_assignments.id > $3
+    AND api_key_role_assignments.id >= $3
 ORDER BY
     api_key_role_assignments.id
 LIMIT $4;

--- a/sqlc/queries-frontend.sql
+++ b/sqlc/queries-frontend.sql
@@ -723,7 +723,7 @@ WHERE
         OR sqlc.narg ('event_name') IS NULL)
     AND (actor_user_id = @actor_user_id
         OR @actor_user_id IS NULL)
-    AND id < @id
+    AND id <= @id
 ORDER BY
     id DESC
 LIMIT $1;

--- a/sqlc/queries-frontend.sql
+++ b/sqlc/queries-frontend.sql
@@ -625,7 +625,7 @@ FROM
     api_keys
 WHERE
     organization_id = $1
-    AND id > $2
+    AND id >= $2
 ORDER BY
     id
 LIMIT $3;
@@ -723,7 +723,7 @@ WHERE
         OR sqlc.narg ('event_name') IS NULL)
     AND (actor_user_id = @actor_user_id
         OR @actor_user_id IS NULL)
-    AND id <= @id
+    AND id < @id
 ORDER BY
     id DESC
 LIMIT $1;


### PR DESCRIPTION
The way that our page token logic works is that it encodes the next ID in a query as the pageToken in the response. This is used in our list queries (ordered by id) to `SELECT ... WHERE id >= @page_token`.

However, in some of our queries, we were selecting `WHERE id > @page_token`. This resulted in single records being dropped when paginating.

This PR updates these queries to select `WHERE id >= @page_token` instead.