### PR TITLE
Fix pagination for audit log queries

### DIFF
--- a/internal/backend/store/queries/queries-backend.sql.go
+++ b/internal/backend/store/queries/queries-backend.sql.go
@@ -130,7 +130,7 @@ WHERE
         OR $11 IS NULL)
     AND (resource_id = $12
         OR $12 IS NULL)
-    AND id < $13
+    AND id <= $13
 ORDER BY
     id DESC
 LIMIT $1

--- a/internal/frontend/store/queries/queries-frontend.sql.go
+++ b/internal/frontend/store/queries/queries-frontend.sql.go
@@ -1628,7 +1628,7 @@ WHERE
         OR $6 IS NULL)
     AND (actor_user_id = $7
         OR $7 IS NULL)
-    AND id < $8
+    AND id <= $8
 ORDER BY
     id DESC
 LIMIT $1

--- a/sqlc/queries-backend.sql
+++ b/sqlc/queries-backend.sql
@@ -1204,7 +1204,7 @@ WHERE
         OR @resource_type IS NULL)
     AND (resource_id = @resource_id
         OR @resource_id IS NULL)
-    AND id < @id
+    AND id <= @id
 ORDER BY
     id DESC
 LIMIT $1;

--- a/sqlc/queries-frontend.sql
+++ b/sqlc/queries-frontend.sql
@@ -723,7 +723,7 @@ WHERE
         OR sqlc.narg ('event_name') IS NULL)
     AND (actor_user_id = @actor_user_id
         OR @actor_user_id IS NULL)
-    AND id < @id
+    AND id <= @id
 ORDER BY
     id DESC
 LIMIT $1;


### PR DESCRIPTION
This is effectively the same fix as #470, but audit logs are sorted in the opposite direction, so this was missed when grepping for queries.

This PR updates the audit log queries to use `WHERE id <= @page_token` instead of `WHERE id < @page_token`.