### PR TITLE
Add pagination to all Console list cards

### DIFF
--- a/console/src/components/core/Pagination.tsx
+++ b/console/src/components/core/Pagination.tsx
@@ -1,0 +1,64 @@
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import React from "react";
+
+import { cn } from "@/lib/utils";
+
+import { Button } from "../ui/button";
+import { Separator } from "../ui/separator";
+
+export function Pagination({
+  count = 0,
+  className = "",
+  hasNextPage = false,
+  hasPreviousPage = false,
+  fetchNextPage = () => {},
+  fetchPreviousPage = () => {},
+}: {
+  className?: string;
+  count?: number;
+  hasNextPage?: boolean;
+  hasPreviousPage?: boolean;
+  fetchNextPage?: () => void;
+  fetchPreviousPage?: () => void;
+}) {
+  return (
+    <>
+      {(hasNextPage || hasPreviousPage) && (
+        <div
+          className={cn(
+            "flex items-center justify-end gap-2 w-full &:first:mb-4",
+            className,
+          )}
+        >
+          <div className="h-9 flex items-center">
+            <span className="px-4 text-sm text-muted-foreground">
+              Showing <span className="font-semibold">{count}</span>{" "}
+              {count > 1 ? "results" : "result"}
+            </span>
+          </div>
+          <div className="h-9 flex items-center border rounded-md">
+            <Button
+              className="rounded-r-none"
+              variant="ghost"
+              size="sm"
+              onClick={fetchPreviousPage}
+              disabled={!hasPreviousPage}
+            >
+              <ChevronLeft />
+            </Button>
+            <Separator orientation="vertical" />
+            <Button
+              className="rounded-l-none"
+              variant="ghost"
+              size="sm"
+              onClick={fetchNextPage}
+              disabled={!hasNextPage}
+            >
+              <ChevronRight />
+            </Button>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/console/src/hooks/use-paginate.tsx
+++ b/console/src/hooks/use-paginate.tsx
@@ -1,0 +1,185 @@
+import {
+  DescMessage,
+  DescMethodUnary,
+  MessageInitShape,
+  MessageShape,
+} from "@bufbuild/protobuf";
+import { ConnectError } from "@connectrpc/connect";
+import {
+  UseInfiniteQueryOptions,
+  useInfiniteQuery,
+} from "@connectrpc/connect-query";
+import {
+  InfiniteData,
+  SkipToken,
+  UseInfiniteQueryResult,
+} from "@tanstack/react-query";
+import React, {
+  PropsWithChildren,
+  createContext,
+  useContext,
+  useEffect,
+  useState,
+} from "react";
+
+type PaginationContextType<O extends DescMessage> = UseInfiniteQueryResult<
+  InfiniteData<MessageShape<O>>,
+  ConnectError
+> & {
+  page: MessageShape<O>;
+  consoleFetchNextPage: () => void;
+  consoleFetchPreviousPage: () => void;
+};
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const PaginationContext = createContext<PaginationContextType<any> | null>(
+  null,
+);
+
+export function PaginationProvider<O extends DescMessage>({
+  children,
+  query,
+}: {
+  query: UseInfiniteQueryResult<InfiniteData<MessageShape<O>>, ConnectError> & {
+    page: MessageShape<O>;
+    consoleFetchNextPage: () => void;
+    consoleFetchPreviousPage: () => void;
+  };
+} & PropsWithChildren) {
+  return (
+    <PaginationContext.Provider value={query}>
+      {children}
+    </PaginationContext.Provider>
+  );
+}
+
+export function usePagination() {
+  const context = useContext(PaginationContext);
+  if (!context)
+    throw new Error(
+      "usePaginationContext must be used inside a PaginationProvider",
+    );
+
+  return context;
+}
+
+export function usePaginatedInfiniteQuery<
+  I extends DescMessage,
+  O extends DescMessage,
+  ParamKey extends keyof MessageInitShape<I>,
+>(
+  schema: DescMethodUnary<I, O>,
+  input:
+    | SkipToken
+    | (MessageInitShape<I> & Required<Pick<MessageInitShape<I>, ParamKey>>),
+  queryOptions: UseInfiniteQueryOptions<I, O, ParamKey>,
+): UseInfiniteQueryResult<InfiniteData<MessageShape<O>>, ConnectError> & {
+  page: MessageShape<O>;
+  consoleFetchNextPage: () => void;
+  consoleFetchPreviousPage: () => void;
+} {
+  const [currentPage, setCurrentPage] = useState(0);
+  const [hasNextPage, setHasNextPage] = useState(false);
+  const [hasPreviousPage, setHasPreviousPage] = useState(false);
+  const [page, setPage] = useState<MessageShape<O>>({} as MessageShape<O>);
+
+  const {
+    data,
+    hasNextPage: queryHasNextPage,
+    fetchNextPage,
+    isFetching,
+    isSuccess,
+    ...result
+  } = useInfiniteQuery(schema, input, {
+    ...queryOptions,
+    retry: queryOptions.retry ?? 3,
+  });
+
+  function consoleFetchNextPage() {
+    const nextPage = currentPage + 1;
+
+    const prefetchedPage = data?.pages[nextPage - 1];
+
+    if (prefetchedPage) {
+      setCurrentPage(nextPage);
+      setPage(prefetchedPage);
+    } else if (queryHasNextPage) {
+      fetchNextPage().then(() => {
+        setCurrentPage(nextPage);
+      });
+    }
+  }
+
+  function consoleFetchPreviousPage() {
+    if (!data || currentPage < 2) {
+      return;
+    }
+
+    const previousPage = currentPage - 1;
+    if (previousPage < 1) {
+      return;
+    }
+
+    const prefetchedPage = data.pages[previousPage - 1];
+    if (prefetchedPage) {
+      setCurrentPage(previousPage);
+      setPage(prefetchedPage);
+    }
+  }
+
+  useEffect(() => {
+    if (data?.pages.length && currentPage === 0) {
+      setCurrentPage(1);
+      setPage(data.pages[0]);
+    }
+  }, [currentPage, data, setCurrentPage, setPage]);
+
+  useEffect(() => {
+    if (data && isSuccess && !isFetching) {
+      const newPageCount = data.pages.length;
+
+      setHasNextPage(currentPage < newPageCount || queryHasNextPage);
+
+      const pageResults = data.pages[currentPage - 1];
+      if (pageResults) {
+        setPage(pageResults);
+      }
+    }
+  }, [
+    currentPage,
+    data,
+    isSuccess,
+    isFetching,
+    queryHasNextPage,
+    setHasNextPage,
+    setPage,
+  ]);
+
+  useEffect(() => {
+    if (!data) {
+      return;
+    }
+
+    setHasPreviousPage(currentPage > 1);
+    setHasNextPage(currentPage < data.pages.length || queryHasNextPage);
+  }, [currentPage, data, queryHasNextPage, setPage, setHasPreviousPage]);
+
+  return {
+    ...result,
+    consoleFetchNextPage,
+    consoleFetchPreviousPage,
+    data,
+    hasNextPage,
+    hasPreviousPage,
+    isFetching,
+    isSuccess,
+    page,
+  } as UseInfiniteQueryResult<
+    InfiniteData<MessageShape<O>, unknown>,
+    ConnectError
+  > & {
+    page: MessageShape<O>;
+    consoleFetchNextPage: () => void;
+    consoleFetchPreviousPage: () => void;
+  };
+}

--- a/console/src/pages/console/organizations/users/UserSessionsTab.tsx
+++ b/console/src/pages/console/organizations/users/UserSessionsTab.tsx
@@ -1,11 +1,12 @@
 import { timestampDate } from "@bufbuild/protobuf/wkt";
-import { useInfiniteQuery, useQuery } from "@connectrpc/connect-query";
+import { useQuery } from "@connectrpc/connect-query";
 import { AlignLeft, Copy } from "lucide-react";
 import { DateTime } from "luxon";
 import React from "react";
 import { Link, useParams } from "react-router";
 import { toast } from "sonner";
 
+import { Pagination } from "@/components/core/Pagination";
 import { TableSkeleton } from "@/components/skeletons/TableSkeleton";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -30,6 +31,10 @@ import {
   listSessions,
 } from "@/gen/tesseral/backend/v1/backend-BackendService_connectquery";
 import { PrimaryAuthFactor } from "@/gen/tesseral/backend/v1/models_pb";
+import {
+  PaginationProvider,
+  usePaginatedInfiniteQuery,
+} from "@/hooks/use-paginate";
 import { toTitleCase } from "@/lib/utils";
 
 export function UserSessionsTab() {
@@ -37,13 +42,7 @@ export function UserSessionsTab() {
   const { data: getUserResponse } = useQuery(getUser, {
     id: userId,
   });
-  const {
-    data: listSessionsResponses,
-    fetchNextPage,
-    hasNextPage,
-    isFetchingNextPage,
-    isLoading,
-  } = useInfiniteQuery(
+  const query = usePaginatedInfiniteQuery(
     listSessions,
     {
       userId,
@@ -54,120 +53,133 @@ export function UserSessionsTab() {
       getNextPageParam: (page) => page.nextPageToken || undefined,
     },
   );
+  const {
+    consoleFetchNextPage: fetchNextPage,
+    consoleFetchPreviousPage: fetchPreviousPage,
+    hasNextPage,
+    hasPreviousPage,
+    isFetching,
+    page,
+  } = query;
 
-  const sessions =
-    listSessionsResponses?.pages.flatMap((page) => page.sessions) || [];
+  const sessions = page?.sessions || [];
 
   return (
-    <Card>
-      <CardHeader>
-        <CardTitle>User Sessions</CardTitle>
-        <CardDescription>
-          Sessions created by {getUserResponse?.user?.email}.
-        </CardDescription>
-      </CardHeader>
-      <CardContent>
-        {isLoading ? (
-          <TableSkeleton />
-        ) : (
-          <>
-            {sessions.length === 0 ? (
-              <div className="text-center text-muted-foreground py-6">
-                No sessions found for this User.
-              </div>
-            ) : (
-              <Table>
-                <TableHeader>
-                  <TableRow>
-                    <TableHead>ID</TableHead>
-                    <TableHead>Auth Method</TableHead>
-                    <TableHead>Status</TableHead>
-                    <TableHead>Created</TableHead>
-                    <TableHead>Last Active</TableHead>
-                    <TableHead>Expires</TableHead>
-                    <TableHead className="text-right">Actions</TableHead>
-                  </TableRow>
-                </TableHeader>
-                <TableBody>
-                  {sessions.map((session) => (
-                    <TableRow key={session.id}>
-                      <TableCell>
-                        <span
-                          className="bg-muted text-muted-foreground px-2 py-1 rounded text-xs font-mono cursor-pointer"
-                          onClick={() => {
-                            navigator.clipboard.writeText(session.id);
-                            toast.success("Session ID copied to clipboard");
-                          }}
-                        >
-                          {session.id}
-                          <Copy className="inline w-3 h-3 ml-1" />
-                        </span>
-                      </TableCell>
-                      <TableCell>
-                        <Badge variant="outline">
-                          {toTitleCase(
-                            PrimaryAuthFactor[session.primaryAuthFactor],
-                          )}
-                        </Badge>
-                      </TableCell>
-                      <TableCell>
-                        {session.revoked ? (
-                          <Badge variant="secondary">Revoked</Badge>
-                        ) : (
-                          <Badge>Active</Badge>
-                        )}
-                      </TableCell>
-                      <TableCell>
-                        {session.createTime &&
-                          DateTime.fromJSDate(
-                            timestampDate(session.createTime),
-                          ).toRelative()}
-                      </TableCell>
-                      <TableCell>
-                        {session.lastActiveTime &&
-                          DateTime.fromJSDate(
-                            timestampDate(session.lastActiveTime),
-                          ).toRelative()}
-                      </TableCell>
-                      <TableCell>
-                        {session.expireTime &&
-                          DateTime.fromJSDate(
-                            timestampDate(session.expireTime),
-                          ).toRelative()}
-                      </TableCell>
-                      <TableCell className="text-right">
-                        <Link
-                          to={`/organizations/${organizationId}/users/${userId}/sessions/${session.id}`}
-                        >
-                          <Button variant="outline" size="sm">
-                            <AlignLeft />
-                            Session Details
-                          </Button>
-                        </Link>
-                      </TableCell>
-                    </TableRow>
-                  ))}
-                  {isFetchingNextPage && (
-                    <TableRow>
-                      <TableCell colSpan={6}>
-                        Loading more sessions...
-                      </TableCell>
-                    </TableRow>
-                  )}
-                </TableBody>
-              </Table>
-            )}
-          </>
-        )}
+    <PaginationProvider query={query}>
+      <Card>
+        <CardHeader>
+          <CardTitle>User Sessions</CardTitle>
+          <CardDescription>
+            Sessions created by {getUserResponse?.user?.email}.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {isFetching ? (
+            <TableSkeleton />
+          ) : (
+            <>
+              {sessions.length === 0 ? (
+                <div className="text-center text-muted-foreground py-6">
+                  No sessions found for this User.
+                </div>
+              ) : (
+                <>
+                  <Pagination
+                    count={sessions.length}
+                    hasNextPage={hasNextPage}
+                    hasPreviousPage={hasPreviousPage}
+                    fetchNextPage={fetchNextPage}
+                    fetchPreviousPage={fetchPreviousPage}
+                  />
+                  <Table>
+                    <TableHeader>
+                      <TableRow>
+                        <TableHead>ID</TableHead>
+                        <TableHead>Auth Method</TableHead>
+                        <TableHead>Status</TableHead>
+                        <TableHead>Created</TableHead>
+                        <TableHead>Last Active</TableHead>
+                        <TableHead>Expires</TableHead>
+                        <TableHead className="text-right">Actions</TableHead>
+                      </TableRow>
+                    </TableHeader>
+                    <TableBody>
+                      {sessions.map((session) => (
+                        <TableRow key={session.id}>
+                          <TableCell>
+                            <span
+                              className="bg-muted text-muted-foreground px-2 py-1 rounded text-xs font-mono cursor-pointer"
+                              onClick={() => {
+                                navigator.clipboard.writeText(session.id);
+                                toast.success("Session ID copied to clipboard");
+                              }}
+                            >
+                              {session.id}
+                              <Copy className="inline w-3 h-3 ml-1" />
+                            </span>
+                          </TableCell>
+                          <TableCell>
+                            <Badge variant="outline">
+                              {toTitleCase(
+                                PrimaryAuthFactor[session.primaryAuthFactor],
+                              )}
+                            </Badge>
+                          </TableCell>
+                          <TableCell>
+                            {session.revoked ? (
+                              <Badge variant="secondary">Revoked</Badge>
+                            ) : (
+                              <Badge>Active</Badge>
+                            )}
+                          </TableCell>
+                          <TableCell>
+                            {session.createTime &&
+                              DateTime.fromJSDate(
+                                timestampDate(session.createTime),
+                              ).toRelative()}
+                          </TableCell>
+                          <TableCell>
+                            {session.lastActiveTime &&
+                              DateTime.fromJSDate(
+                                timestampDate(session.lastActiveTime),
+                              ).toRelative()}
+                          </TableCell>
+                          <TableCell>
+                            {session.expireTime &&
+                              DateTime.fromJSDate(
+                                timestampDate(session.expireTime),
+                              ).toRelative()}
+                          </TableCell>
+                          <TableCell className="text-right">
+                            <Link
+                              to={`/organizations/${organizationId}/users/${userId}/sessions/${session.id}`}
+                            >
+                              <Button variant="outline" size="sm">
+                                <AlignLeft />
+                                Session Details
+                              </Button>
+                            </Link>
+                          </TableCell>
+                        </TableRow>
+                      ))}
+                    </TableBody>
+                  </Table>
+                </>
+              )}
+            </>
+          )}
 
-        {hasNextPage && (
           <CardFooter>
-            <Button onClick={() => fetchNextPage()} variant="outline" size="sm">
-              Load More
-            </Button>
+            <Pagination
+              count={sessions.length}
+              hasNextPage={hasNextPage}
+              hasPreviousPage={hasPreviousPage}
+              fetchNextPage={fetchNextPage}
+              fetchPreviousPage={fetchPreviousPage}
+            />
           </CardFooter>
-        )}
-      </CardContent>
-    </Card>
+        </CardContent>
+      </Card>
+    </PaginationProvider>
   );
 }


### PR DESCRIPTION
This PR creates a new `usePaginatedInfiniteQuery` hook that piggybacks on the `userInfiniteQuery` hook, but tracks page state and adds custom fetchers for next and previous page to prioritize in-memory pages.

It also creates a `Pagination` component that handles next and previous page navigation, taking values from the `usePaginatedInfiniteQuery` response as props.

Those two components are integrated into all list cards within the console.

### Example from the Organizations Page
<img width="1643" alt="Screenshot 2025-06-18 at 3 03 22 PM" src="https://github.com/user-attachments/assets/be534254-ee5f-4ba9-8b71-a21b23d863a4" />
