### PR TITLE
Enforce restrictions around secret tokens when apiKeysEnabled is true

### DIFF
--- a/console/src/pages/console/settings/authentication/ManagedApiKeySettingsCard.tsx
+++ b/console/src/pages/console/settings/authentication/ManagedApiKeySettingsCard.tsx
@@ -166,6 +166,18 @@ export function ConfigureManagedApiKeysButton() {
   }
 
   async function handleSubmit(data: z.infer<typeof schema>) {
+    if (
+      data.apiKeysEnabled &&
+      (!data.apiKeySecretTokenPrefix ||
+        data.apiKeySecretTokenPrefix.trim() === "")
+    ) {
+      form.setError("apiKeySecretTokenPrefix", {
+        message:
+          "API Key Secret Token Prefix is required when Managed API Keys are enabled.",
+      });
+      return;
+    }
+
     await updateProjectMutation.mutateAsync({
       project: {
         apiKeysEnabled: data.apiKeysEnabled,


### PR DESCRIPTION
When enabling Managed API Keys at the Project level, a secret token prefix is required. Currently the server fails if no secret token prefix is provided.

This PR also adds a client-side check to fail earlier if no secret token prefix is provided.

<img width="583" alt="Screenshot 2025-06-19 at 3 33 38 PM" src="https://github.com/user-attachments/assets/b905ddae-70df-4398-884a-673fb3a6327f" />
