### PR TITLE
Fix logic for rendering SAML card

### DIFF
--- a/console/src/pages/console/organizations/OrganizationAuthenticationTab.tsx
+++ b/console/src/pages/console/organizations/OrganizationAuthenticationTab.tsx
@@ -42,9 +42,7 @@ export function OrganizationAuthentication() {
           <OrganizationMFACard />
         )}
 
-        {getOrganizationResponse?.organization?.logInWithSaml && (
-          <OrganizationSamlCard />
-        )}
+        {getProjectResponse?.project?.logInWithSaml && <OrganizationSamlCard />}
 
         <OrganizationScimCard />
       </div>


### PR DESCRIPTION
The rendering of Organization SAML settings in the console is currently conditionally rendering based on an Organization property instead of a Project property. This PR fixes the condition to use the correct Project property instead.