### PR TITLE
Fix Console dialog for SAML settings

### DIFF
--- a/console/src/pages/console/settings/authentication/EnterpriseSettingsCard.tsx
+++ b/console/src/pages/console/settings/authentication/EnterpriseSettingsCard.tsx
@@ -120,23 +120,23 @@ function ConfigureEnterpriseSettingsButton() {
   }, [getProjectResponse, form]);
 
   return (
-    <Form {...form}>
-      <form onSubmit={form.handleSubmit(handleSubmit)}>
-        <Dialog open={open} onOpenChange={setOpen}>
-          <DialogTrigger asChild>
-            <Button variant="outline" className="w-full">
-              <Settings />
-              Configure Enterprise Settings
-            </Button>
-          </DialogTrigger>
-          <DialogContent>
-            <DialogHeader>
-              <DialogTitle>Configure Enterprise Settings</DialogTitle>
-              <DialogDescription>
-                Configure whether users can log in with SAML SSO.
-              </DialogDescription>
-            </DialogHeader>
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button variant="outline" className="w-full">
+          <Settings />
+          Configure Enterprise Settings
+        </Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Configure Enterprise Settings</DialogTitle>
+          <DialogDescription>
+            Configure whether users can log in with SAML SSO.
+          </DialogDescription>
+        </DialogHeader>
 
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(handleSubmit)}>
             <div className="space-y-4">
               <FormField
                 control={form.control}
@@ -179,9 +179,9 @@ function ConfigureEnterpriseSettingsButton() {
                   : "Save Changes"}
               </Button>
             </DialogFooter>
-          </DialogContent>
-        </Dialog>
-      </form>
-    </Form>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
   );
 }


### PR DESCRIPTION
Previously, clicking the "Save" button in the SAML settings dialog would not trigger the form submission, making the button non-functional.