### PR TITLE
Add organization domains back to console

### DIFF
--- a/console/src/pages/console/organizations/authentication/OrganizationSamlCard.tsx
+++ b/console/src/pages/console/organizations/authentication/OrganizationSamlCard.tsx
@@ -151,7 +151,7 @@ export function OrganizationSamlCard() {
               <FormField
                 control={form.control}
                 name="domains"
-                render={({ field }: { field: any }) => (
+                render={({ field }) => (
                   <FormItem>
                     <FormLabel>SAML / SCIM Domains</FormLabel>
                     <FormDescription>


### PR DESCRIPTION
With the Console redesign, we missed the inclusion of organization domain settings. This PR adds this setting back in.

![Screenshot 2025-06-23 at 2 32 50 PM](https://github.com/user-attachments/assets/388ae62e-587e-46f1-8f56-5a9d1cc3e98f)
