### PR TITLE
Add proactive access token refresh

### DIFF
--- a/console/src/lib/access-token-provider.tsx
+++ b/console/src/lib/access-token-provider.tsx
@@ -67,7 +67,7 @@ function useAccessTokenLikelyValid(accessToken: string): {
   accessTokenLikelyValid: boolean;
   exp: number;
 } {
-  const now = useDebouncedNow(10 * 1000); // re-check expiration every 10 seconds
+  const now = useDebouncedNow(2 * 1000); // re-check expiration every 2 seconds
   return useMemo(() => {
     if (!accessToken) {
       return {

--- a/console/src/lib/access-token-provider.tsx
+++ b/console/src/lib/access-token-provider.tsx
@@ -52,7 +52,7 @@ function useAccessTokenInternal(): string | undefined {
         }
       }
     })();
-  }, [accessTokenLikelyValid]);
+  }, [accessTokenLikelyValid, navigate, refreshMutation]);
 
   useEffect(() => {
     // Proactively refresh the access token every 10 seconds.

--- a/console/src/lib/access-token-provider.tsx
+++ b/console/src/lib/access-token-provider.tsx
@@ -30,7 +30,7 @@ function useAccessTokenInternal(): string | undefined {
     return getCookie(`tesseral_${DOGFOOD_PROJECT_ID}_access_token`);
   });
   const { mutateAsync: refreshAsync } = useMutation(refresh);
-  const { accessTokenLikelyValid, exp } = useAccessTokenLikelyValid(
+  const { accessTokenLikelyValid } = useAccessTokenLikelyValid(
     accessToken ?? "",
   );
 
@@ -53,29 +53,6 @@ function useAccessTokenInternal(): string | undefined {
       }
     })();
   }, [accessTokenLikelyValid, navigate, refreshAsync]);
-
-  useEffect(() => {
-    // Proactively refresh the access token every 10 seconds.
-    const interval = setInterval(() => {
-      const now = Date.now() / 1000;
-
-      if (exp && exp - now < 10) {
-        refreshAsync({})
-          .then(({ accessToken }) => {
-            setAccessToken(accessToken);
-          })
-          .catch((e) => {
-            if (e instanceof ConnectError && e.code === Code.Unauthenticated) {
-              navigate("/login");
-            } else {
-              setError(`Unexpected response from /api/frontend/refresh: ${e}`);
-            }
-          });
-      }
-    }, ACCESS_TOKEN_EXPIRY_BUFFER_MILLIS); // every 10 seconds
-
-    return () => clearInterval(interval);
-  }, [exp, refreshAsync, setAccessToken, navigate]);
 
   if (error) {
     throw error;

--- a/console/src/lib/access-token-provider.tsx
+++ b/console/src/lib/access-token-provider.tsx
@@ -29,7 +29,7 @@ function useAccessTokenInternal(): string | undefined {
   const [accessToken, setAccessToken] = useState(() => {
     return getCookie(`tesseral_${DOGFOOD_PROJECT_ID}_access_token`);
   });
-  const refreshMutation = useMutation(refresh);
+  const { mutateAsync: refreshAsync } = useMutation(refresh);
   const { accessTokenLikelyValid, exp } = useAccessTokenLikelyValid(
     accessToken ?? "",
   );
@@ -42,7 +42,7 @@ function useAccessTokenInternal(): string | undefined {
 
     (async () => {
       try {
-        const { accessToken } = await refreshMutation.mutateAsync({});
+        const { accessToken } = await refreshAsync({});
         setAccessToken(accessToken);
       } catch (e) {
         if (e instanceof ConnectError && e.code === Code.Unauthenticated) {
@@ -52,7 +52,7 @@ function useAccessTokenInternal(): string | undefined {
         }
       }
     })();
-  }, [accessTokenLikelyValid, navigate, refreshMutation]);
+  }, [accessTokenLikelyValid, navigate, refreshAsync]);
 
   useEffect(() => {
     // Proactively refresh the access token every 10 seconds.
@@ -60,8 +60,7 @@ function useAccessTokenInternal(): string | undefined {
       const now = Date.now() / 1000;
 
       if (exp && exp - now < 10) {
-        refreshMutation
-          .mutateAsync({})
+        refreshAsync({})
           .then(({ accessToken }) => {
             setAccessToken(accessToken);
           })
@@ -76,7 +75,7 @@ function useAccessTokenInternal(): string | undefined {
     }, ACCESS_TOKEN_EXPIRY_BUFFER_MILLIS); // every 10 seconds
 
     return () => clearInterval(interval);
-  }, [exp, refreshMutation, setAccessToken, navigate]);
+  }, [exp, refreshAsync, setAccessToken, navigate]);
 
   if (error) {
     throw error;

--- a/vault-ui/src/components/page/LoggedInGate.tsx
+++ b/vault-ui/src/components/page/LoggedInGate.tsx
@@ -36,7 +36,7 @@ function useAccessTokenInternal(): string | undefined {
     return parseAccessToken(accessToken);
   }, [accessToken]);
 
-  const now = useDebouncedNow(1000 * 10); // Re-check every 10 seconds
+  const now = useDebouncedNow(1000 * 2); // Re-check every 2 seconds
   const accessTokenIsLikelyValid = useMemo(() => {
     if (!parsedAccessToken || !parsedAccessToken.exp) {
       return false;

--- a/vault-ui/src/components/page/LoggedInGate.tsx
+++ b/vault-ui/src/components/page/LoggedInGate.tsx
@@ -36,7 +36,7 @@ function useAccessTokenInternal(): string | undefined {
     return parseAccessToken(accessToken);
   }, [accessToken]);
 
-  const now = useDebouncedNow(1000 * 60);
+  const now = useDebouncedNow(1000 * 10); // Rechec every 10 seconds
   const accessTokenIsLikelyValid = useMemo(() => {
     if (!parsedAccessToken || !parsedAccessToken.exp) {
       return false;
@@ -69,34 +69,11 @@ function useAccessTokenInternal(): string | undefined {
     void refreshAccessToken();
   }, [accessTokenIsLikelyValid, setAccessToken, refreshAsync, navigate]);
 
-  useEffect(() => {
-    // Proactively refresh the access token every 10 seconds.
-    const interval = setInterval(() => {
-      const now = Date.now() / 1000;
-
-      if (parsedAccessToken?.exp && parsedAccessToken.exp <= now) {
-        refreshAsync({})
-          .then(({ accessToken }) => {
-            setAccessToken(accessToken!);
-          })
-          .catch((e) => {
-            if (e instanceof ConnectError && e.code === Code.Unauthenticated) {
-              navigate("/login");
-            } else {
-              console.error("Error refreshing access token:", e);
-            }
-          });
-      }
-    }, 10_000);
-
-    return () => clearInterval(interval);
-  }, [parsedAccessToken?.exp, refreshAsync, setAccessToken, navigate]);
-
   if (accessTokenIsLikelyValid) {
     return accessToken!;
   }
 
-  return undefined;
+  return;
 }
 
 function useDebouncedNow(updatePeriodMillis: number): number {

--- a/vault-ui/src/components/page/LoggedInGate.tsx
+++ b/vault-ui/src/components/page/LoggedInGate.tsx
@@ -36,7 +36,7 @@ function useAccessTokenInternal(): string | undefined {
     return parseAccessToken(accessToken);
   }, [accessToken]);
 
-  const now = useDebouncedNow(1000 * 10); // Rechec every 10 seconds
+  const now = useDebouncedNow(1000 * 10); // Re-check every 10 seconds
   const accessTokenIsLikelyValid = useMemo(() => {
     if (!parsedAccessToken || !parsedAccessToken.exp) {
       return false;


### PR DESCRIPTION
Currently, if pages are left idle on the console or vault, the access token becomes invalid and react query's automatic refetching will start to 401.

The vault is currently polling on a 60-second cadence, which can result in up to 50 seconds of expired access tokens. This PR updates both the vault and console to poll on a 2 second interval to check if refresh is required.