### PR TITLE
Add console redirect for trusted domains

### DIFF
--- a/console/src/App.tsx
+++ b/console/src/App.tsx
@@ -86,6 +86,10 @@ function AppWithinQueryClient() {
       <BrowserRouter>
         <Routes>
           <Route
+            path="/project-settings"
+            element={<Navigate to="/settings/vault/domains" replace />}
+          />
+          <Route
             path="/project-settings/publishable-keys"
             element={<Navigate to="/settings/api-keys" replace />}
           />


### PR DESCRIPTION
In the Tesseral SDKs we advertise `console.tesseral.com/project-settings` for updating trusted domains. Similar to the existing redirect for publishable keys, we add one for trusted domains.