### PR TITLE
Migrate away from alpine

### DIFF
--- a/cmd/api/Dockerfile
+++ b/cmd/api/Dockerfile
@@ -1,6 +1,6 @@
-FROM --platform=$BUILDPLATFORM golang:1.24-alpine AS build
+FROM --platform=$BUILDPLATFORM golang:1.24 AS build
 
-RUN apk update && apk add --no-cache git ca-certificates tzdata && update-ca-certificates
+RUN apt update && apt install -y git ca-certificates tzdata && update-ca-certificates
 
 WORKDIR /work
 

--- a/console/Dockerfile
+++ b/console/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22.11.0-alpine
+FROM node:22.11.0
  
 WORKDIR /usr/src/app
  

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -46,7 +46,7 @@ services:
       - ./.local/kms/data/:/data/
       - ./.local/kms/seed.yaml:/init/seed.yaml
   nginx:
-    image: nginx:1-alpine
+    image: nginx:1
     ports:
       - "80:80"
       - "443:443"

--- a/vault-ui/Dockerfile
+++ b/vault-ui/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22.11.0-alpine
+FROM node:22.11.0
  
 WORKDIR /usr/src/app
  


### PR DESCRIPTION
Alpine is known to have a very slow memory allocator leading to longer iteration times when running locally