### PR TITLE
Add replica identity to enable cascading deletes of email quota records

### DIFF
--- a/cmd/openauthctl/migrations/000083_fix_email_quota_deletes.up.sql
+++ b/cmd/openauthctl/migrations/000083_fix_email_quota_deletes.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE project_email_quota_daily_usage
+REPLICA IDENTITY FULL;


### PR DESCRIPTION
Since there is no primary key on the `project_email_quota_daily_usage` table, cascading deletes break as there is no replica identity. Typically, with 1:1 tables (if we only had one record per project), we could just make the project ID the primary key.

Since this is not the case, we need to use the full record as the replica identity in order to postgres to be able to properly track cascading deletes.

This PR alters the table to include this replica identity.