### PR TITLE
Fix passkeys

### DIFF
--- a/console/src/pages/login/VerifyPasskeyPage.tsx
+++ b/console/src/pages/login/VerifyPasskeyPage.tsx
@@ -42,6 +42,7 @@ export function VerifyPasskeyPage() {
       userVerification: "preferred",
       timeout: 60000,
     };
+
     const credential = (await navigator.credentials.get({
       publicKey: requestOptions,
     })) as PublicKeyCredential;

--- a/internal/frontend/store/passkeys.go
+++ b/internal/frontend/store/passkeys.go
@@ -127,7 +127,7 @@ func (s *Store) GetPasskeyOptions(ctx context.Context, req *frontendv1.GetPasske
 	}
 
 	return &frontendv1.GetPasskeyOptionsResponse{
-		RpId:            qProject.VaultDomain,
+		RpId:            qProject.CookieDomain,
 		RpName:          qProject.DisplayName,
 		UserId:          fmt.Sprintf("%s|%s", qUser.Email, idformat.Organization.Format(qUser.OrganizationID)),
 		UserDisplayName: qUser.Email,
@@ -147,7 +147,7 @@ func (s *Store) RegisterPasskey(ctx context.Context, req *frontendv1.RegisterPas
 	}
 
 	cred, err := webauthn.Parse(&webauthn.ParseRequest{
-		RPID:              qProject.VaultDomain,
+		RPID:              qProject.CookieDomain,
 		AttestationObject: req.AttestationObject,
 	})
 	if err != nil {

--- a/internal/intermediate/store/passkeys.go
+++ b/internal/intermediate/store/passkeys.go
@@ -37,7 +37,7 @@ func (s *Store) GetPasskeyOptions(ctx context.Context, req *intermediatev1.GetPa
 	}
 
 	return &intermediatev1.GetPasskeyOptionsResponse{
-		RpId:            qProject.VaultDomain,
+		RpId:            qProject.CookieDomain,
 		RpName:          qProject.DisplayName,
 		UserId:          fmt.Sprintf("%s|%s", *qIntermediateSession.Email, idformat.Organization.Format(*qIntermediateSession.OrganizationID)),
 		UserDisplayName: *qIntermediateSession.Email,
@@ -61,7 +61,7 @@ func (s *Store) RegisterPasskey(ctx context.Context, req *intermediatev1.Registe
 	}
 
 	cred, err := webauthn.Parse(&webauthn.ParseRequest{
-		RPID:              qProject.VaultDomain,
+		RPID:              qProject.CookieDomain,
 		AttestationObject: req.AttestationObject,
 	})
 	if err != nil {
@@ -143,7 +143,7 @@ func (s *Store) IssuePasskeyChallenge(ctx context.Context, req *intermediatev1.I
 	}
 
 	return &intermediatev1.IssuePasskeyChallengeResponse{
-		RpId:          qProject.VaultDomain,
+		RpId:          qProject.CookieDomain,
 		CredentialIds: credentialIDs,
 		Challenge:     challenge[:],
 	}, nil


### PR DESCRIPTION
Currently, our Passkey Relying Party ID is operating on the assumptions built up by the Google and Safari implementation of domain restriction (which allow for subdomains of the current origin as a valid RP ID). However, their implementations stray a bit from [the spec itself](https://www.w3.org/TR/webauthn-2/#rp-id) which states that the RP ID `must be equal to the origin's effective domain, or a registrable domain suffix of the origin's effective domain`.

This PR updates our Passkey rpcs for issuing challenges and getting options for Passkey registration and verification in both the frontend and intermediate stores to use the Project's `cookie_domain` instead of the `vault_domain`. This loosely ensures stronger compatibility with the expectations of the spec (and solves some problems with Passkeys in Firefox).

This has been confirmed working in Chrome, Firefox, and Safari both locally and on dev1.