### PR TITLE
Allow deletion of projects

### DIFF
--- a/cmd/openauthctl/migrations/000084_audit_log_events_project_id.up.sql
+++ b/cmd/openauthctl/migrations/000084_audit_log_events_project_id.up.sql
@@ -1,0 +1,6 @@
+alter table audit_log_events drop constraint if exists audit_log_events_project_id_fkey;
+
+alter table audit_log_events alter column project_id drop not null;
+
+alter table audit_log_events add constraint audit_log_events_project_id_fkey
+    foreign key (project_id) references projects(id) on delete set null;

--- a/cmd/openauthctl/migrations/000084_audit_log_events_project_id.up.sql
+++ b/cmd/openauthctl/migrations/000084_audit_log_events_project_id.up.sql
@@ -1,6 +1,4 @@
 alter table audit_log_events drop constraint if exists audit_log_events_project_id_fkey;
 
-alter table audit_log_events alter column project_id drop not null;
-
 alter table audit_log_events add constraint audit_log_events_project_id_fkey
-    foreign key (project_id) references projects(id) on delete set null;
+    foreign key (project_id) references projects(id) on delete cascade;


### PR DESCRIPTION
Updates the `audit_log_events` table to allow the `project_id` column to be nullable, enabling the deletion of projects without affecting existing audit log events.