### PR TITLE
[OPEN-509] Allow creation of dev mode publishable keys

### DIFF
--- a/console/src/pages/console/settings/api-keys/publishable-keys/ListPublishableKeysCard.tsx
+++ b/console/src/pages/console/settings/api-keys/publishable-keys/ListPublishableKeysCard.tsx
@@ -431,6 +431,7 @@ function CreatePublishableKeyButton() {
     await createPublishableKeyMutation.mutateAsync({
       publishableKey: {
         displayName: data.displayName,
+        devMode: data.devMode,
       },
     });
     form.reset(data);


### PR DESCRIPTION
When selecting the "Development mode" checkbox, pass the `devMode` property to the backend API.