### PR TITLE
Preserve original query params on redirect

### DIFF
--- a/vault-ui/src/pages/login/FinishLoginPage.tsx
+++ b/vault-ui/src/pages/login/FinishLoginPage.tsx
@@ -27,10 +27,11 @@ export function FinishLoginPage() {
       const url = new URL(redirectUri || preferredRedirect);
 
       if (relayedSessionToken) {
-        const params = new URLSearchParams({
-          [`__tesseral_${settings.projectId}_relayed_session_token`]:
-            relayedSessionToken,
-        });
+        const params = new URLSearchParams(url.search);
+        params.set(
+          `__tesseral_${settings.projectId}_relayed_session_token`,
+          relayedSessionToken,
+        );
 
         if (returnRelayedSessionTokenAsQueryParam) {
           params.set(


### PR DESCRIPTION
This PR ensures that when passing along a redirect URI with search params, they are preserved on redirect when using relayed sessions.