### PR TITLE
Fix redirect URI handling in FinishLoginPage

### DIFF
--- a/vault-ui/src/pages/login/FinishLoginPage.tsx
+++ b/vault-ui/src/pages/login/FinishLoginPage.tsx
@@ -27,18 +27,19 @@ export function FinishLoginPage() {
       const url = new URL(redirectUri || preferredRedirect);
 
       if (relayedSessionToken) {
-        const params = new URLSearchParams(url.search);
-        params.set(
-          `__tesseral_${settings.projectId}_relayed_session_token`,
-          relayedSessionToken,
-        );
+        const params = new URLSearchParams({
+          [`__tesseral_${settings.projectId}_relayed_session_token`]:
+            relayedSessionToken,
+        });
 
         if (returnRelayedSessionTokenAsQueryParam) {
           params.set(
             `__tesseral_${settings.projectId}_redirect_uri`,
             preferredRedirect,
           );
-          url.search = params.toString();
+          for (const [key, value] of params.entries()) {
+            url.searchParams.set(key, value);
+          }
         } else {
           url.hash = params.toString();
         }

--- a/vault-ui/src/pages/login/FinishLoginPage.tsx
+++ b/vault-ui/src/pages/login/FinishLoginPage.tsx
@@ -27,21 +27,20 @@ export function FinishLoginPage() {
       const url = new URL(redirectUri || preferredRedirect);
 
       if (relayedSessionToken) {
-        const params = new URLSearchParams({
-          [`__tesseral_${settings.projectId}_relayed_session_token`]:
-            relayedSessionToken,
-        });
-
         if (returnRelayedSessionTokenAsQueryParam) {
-          params.set(
+          url.searchParams.set(
+            `__tesseral_${settings.projectId}_relayed_session_token`,
+            relayedSessionToken,
+          );
+          url.searchParams.set(
             `__tesseral_${settings.projectId}_redirect_uri`,
             preferredRedirect,
           );
-          for (const [key, value] of params.entries()) {
-            url.searchParams.set(key, value);
-          }
         } else {
-          url.hash = params.toString();
+          url.hash = new URLSearchParams({
+            [`__tesseral_${settings.projectId}_relayed_session_token`]:
+              relayedSessionToken,
+          }).toString();
         }
       }
 


### PR DESCRIPTION
In dev mode, when using hash, only include Tesseral parameters in the redirect hash. Currently, if the redirect URI has query parameters, they are included in the hash which breaks the dev mode callback logic in the React SDK.