### PR TITLE
[OPEN-538] First SAML/OIDC connection should be primary

### DIFF
--- a/console/src/pages/console/organizations/authentication/ListOrganizationOidcConnectionsCard.tsx
+++ b/console/src/pages/console/organizations/authentication/ListOrganizationOidcConnectionsCard.tsx
@@ -198,7 +198,7 @@ function CreateOidcConnectionButton() {
   const { organizationId } = useParams();
   const navigate = useNavigate();
 
-  const { refetch } = useInfiniteQuery(
+  const { data: listOidcConnectionsResponse, refetch } = useInfiniteQuery(
     listOIDCConnections,
     {
       organizationId,
@@ -212,9 +212,12 @@ function CreateOidcConnectionButton() {
   const createOidcConnectionMutation = useMutation(createOIDCConnection);
 
   async function handleCreateOidcConnection() {
+    const isFirstOidcConnection =
+      listOidcConnectionsResponse?.pages[0]?.oidcConnections.length === 0;
     const newOidcConnection = await createOidcConnectionMutation.mutateAsync({
       oidcConnection: {
         organizationId,
+        primary: isFirstOidcConnection,
       },
     });
 

--- a/console/src/pages/console/organizations/authentication/ListOrganizationSamlConnectionsCard.tsx
+++ b/console/src/pages/console/organizations/authentication/ListOrganizationSamlConnectionsCard.tsx
@@ -166,7 +166,7 @@ function CreateSamlConnectionButton() {
   const { organizationId } = useParams();
   const navigate = useNavigate();
 
-  const { refetch } = useInfiniteQuery(
+  const { data: listSamlConnectionsResponse, refetch } = useInfiniteQuery(
     listSAMLConnections,
     {
       organizationId,
@@ -180,9 +180,12 @@ function CreateSamlConnectionButton() {
   const createSamlConnectionMutation = useMutation(createSAMLConnection);
 
   async function handleCreateSamlConnection() {
+    const isFirstSamlConnection =
+      listSamlConnectionsResponse?.pages[0]?.samlConnections.length === 0;
     const newSamlConnection = await createSamlConnectionMutation.mutateAsync({
       samlConnection: {
         organizationId,
+        primary: isFirstSamlConnection,
       },
     });
 

--- a/vault-ui/src/pages/vault/organization/oidc-connections/OidcConnectionsCard.tsx
+++ b/vault-ui/src/pages/vault/organization/oidc-connections/OidcConnectionsCard.tsx
@@ -81,9 +81,13 @@ export function OidcConnectionsCard() {
 
   async function handleCreate() {
     try {
+      const isFirstOidcConnection =
+        listOidcConnectionsResponses?.pages[0]?.oidcConnections.length === 0;
       const { oidcConnection } = await createOidcConnectionMutation.mutateAsync(
         {
-          oidcConnection: {},
+          oidcConnection: {
+            primary: isFirstOidcConnection,
+          },
         },
       );
       if (!oidcConnection) {

--- a/vault-ui/src/pages/vault/organization/saml-connections/SamlConnectionsCard.tsx
+++ b/vault-ui/src/pages/vault/organization/saml-connections/SamlConnectionsCard.tsx
@@ -88,9 +88,13 @@ export function SamlConnectionsCard() {
 
   async function handleCreate() {
     try {
+      const isFirstSamlConnection =
+        listSamlConnectionsResponses?.pages[0]?.samlConnections.length === 0;
       const { samlConnection } = await createSamlConnectionMutation.mutateAsync(
         {
-          samlConnection: {},
+          samlConnection: {
+            primary: isFirstSamlConnection,
+          },
         },
       );
       if (!samlConnection) {


### PR DESCRIPTION
When creating SAML/OIDC connections in the vault or console, mark it primary if it is the first connection for that organization.