### PR TITLE
[OPEN-525] Better reset password dialog handling

### DIFF
--- a/vault-ui/src/pages/vault/user/UserDetailsTab.tsx
+++ b/vault-ui/src/pages/vault/user/UserDetailsTab.tsx
@@ -268,7 +268,6 @@ function DangerZoneCard() {
                       Enter your new password. It must be at least 8 characters
                       long.
                     </FormDescription>
-                    <FormMessage />
                     <FormControl>
                       <Input
                         {...field}
@@ -290,7 +289,6 @@ function DangerZoneCard() {
                     <FormDescription>
                       Re-enter your new password to confirm.
                     </FormDescription>
-                    <FormMessage />
                     <FormControl>
                       <Input
                         {...field}

--- a/vault-ui/src/pages/vault/user/UserDetailsTab.tsx
+++ b/vault-ui/src/pages/vault/user/UserDetailsTab.tsx
@@ -167,9 +167,15 @@ export function UserDetailsTab() {
   );
 }
 
-const resetSchema = z.object({
-  password: z.string().min(8, "Password must be at least 8 characters long"),
-});
+const resetSchema = z
+  .object({
+    password: z.string().min(8, "Password must be at least 8 characters long"),
+    confirmPassword: z.string(),
+  })
+  .refine((data) => data.password === data.confirmPassword, {
+    message: "Passwords do not match",
+    path: ["confirmPassword"],
+  });
 
 function DangerZoneCard() {
   const { data: getOrganizationResponse } = useQuery(getOrganization, {});
@@ -182,6 +188,7 @@ function DangerZoneCard() {
     resolver: zodResolver(resetSchema),
     defaultValues: {
       password: "",
+      confirmPassword: "",
     },
   });
 
@@ -274,17 +281,38 @@ function DangerZoneCard() {
                   </FormItem>
                 )}
               />
+              <FormField
+                control={form.control}
+                name="confirmPassword"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Confirm Password</FormLabel>
+                    <FormDescription>
+                      Re-enter your new password to confirm.
+                    </FormDescription>
+                    <FormMessage />
+                    <FormControl>
+                      <Input
+                        {...field}
+                        type="password"
+                        placeholder="••••••••"
+                        autoComplete="new-password"
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <DialogFooter>
+                <Button variant="outline" onClick={() => setResetOpen(false)}>
+                  Cancel
+                </Button>
+                <Button type="submit" disabled={!form.formState.isDirty}>
+                  Change password
+                </Button>
+              </DialogFooter>
             </form>
           </Form>
-
-          <DialogFooter>
-            <Button variant="outline" onClick={() => setResetOpen(false)}>
-              Cancel
-            </Button>
-            <Button type="submit" disabled={!form.formState.isDirty}>
-              Change password
-            </Button>
-          </DialogFooter>
         </DialogContent>
       </Dialog>
     </>


### PR DESCRIPTION
- Fixes bug where the Change Password button did nothing (moved the `DialogFooter` inside the `form` so that `type=submit` works).
- Removes double `FormMessage` elements
- Adds a confirm password field to the reset password dialog.

<img width="1840" alt="Screenshot 2025-07-07 at 1 05 42 PM" src="https://github.com/user-attachments/assets/f165d815-3b9e-41f1-9d5f-1727819c62e2" />