### PR TITLE
Fix pgformatter

### DIFF
--- a/.github/workflows/pgformat-lint.yml
+++ b/.github/workflows/pgformat-lint.yml
@@ -17,9 +17,14 @@ jobs:
           go-version: stable
       - name: pg_format check
         run: |
-          diff sqlc/queries.sql <(docker run --quiet --rm --volume "$(pwd)/sqlc/queries.sql:/work/queries.sql" backplane/pgformatter queries.sql)
-          diff sqlc/queries-backend.sql <(docker run --quiet --rm --volume "$(pwd)/sqlc/queries-backend.sql:/work/queries.sql" backplane/pgformatter queries.sql)
-          diff sqlc/queries-frontend.sql <(docker run --quiet --rm --volume "$(pwd)/sqlc/queries-frontend.sql:/work/queries.sql" backplane/pgformatter queries.sql)
-          diff sqlc/queries-intermediate.sql <(docker run --quiet --rm --volume "$(pwd)/sqlc/queries-intermediate.sql:/work/queries.sql" backplane/pgformatter queries.sql)
-          diff sqlc/queries-saml.sql <(docker run --quiet --rm --volume "$(pwd)/sqlc/queries-saml.sql:/work/queries.sql" backplane/pgformatter queries.sql)
-          diff sqlc/queries-scim.sql <(docker run --quiet --rm --volume "$(pwd)/sqlc/queries-scim.sql:/work/queries.sql" backplane/pgformatter queries.sql)
+          diff sqlc/queries.sql <(./bin/pg_format/pg_format sqlc/queries.sql)
+          diff sqlc/queries-auditlog.sql <(./bin/pg_format/pg_format sqlc/queries-auditlog.sql)
+          diff sqlc/queries-backend.sql <(./bin/pg_format/pg_format sqlc/queries-backend.sql)
+          diff sqlc/queries-frontend.sql <(./bin/pg_format/pg_format sqlc/queries-frontend.sql)
+          diff sqlc/queries-intermediate.sql <(./bin/pg_format/pg_format sqlc/queries-intermediate.sql)
+          diff sqlc/queries-saml.sql <(./bin/pg_format/pg_format sqlc/queries-saml.sql)
+          diff sqlc/queries-oidc.sql <(./bin/pg_format/pg_format sqlc/queries-oidc.sql)
+          diff sqlc/queries-scim.sql <(./bin/pg_format/pg_format sqlc/queries-scim.sql)
+          diff sqlc/queries-common.sql <(./bin/pg_format/pg_format sqlc/queries-common.sql)
+          diff sqlc/queries-wellknown.sql <(./bin/pg_format/pg_format sqlc/queries-wellknown.sql)
+          diff sqlc/queries-configapi.sql <(./bin/pg_format/pg_format sqlc/queries-configapi.sql)

--- a/Makefile
+++ b/Makefile
@@ -46,16 +46,27 @@ proto:
 
 .PHONY: queries
 queries:
-	rm -rf internal/store/queries internal/auditlog/store/queries internal/backend/store/queries internal/frontend/store/queries internal/intermediate/store/queries internal/saml/store/queries internal/scim/store/queries internal/common/store/queries internal/wellknown/store/queries internal/configapi/store/queries
-	docker run --rm --volume "$$(pwd)/sqlc/queries.sql:/work/queries.sql" backplane/pgformatter -i queries.sql
-	docker run --rm --volume "$$(pwd)/sqlc/queries-auditlog.sql:/work/queries.sql" backplane/pgformatter -i queries.sql
-	docker run --rm --volume "$$(pwd)/sqlc/queries-backend.sql:/work/queries.sql" backplane/pgformatter -i queries.sql
-	docker run --rm --volume "$$(pwd)/sqlc/queries-frontend.sql:/work/queries.sql" backplane/pgformatter -i queries.sql
-	docker run --rm --volume "$$(pwd)/sqlc/queries-intermediate.sql:/work/queries.sql" backplane/pgformatter -i queries.sql
-	docker run --rm --volume "$$(pwd)/sqlc/queries-saml.sql:/work/queries.sql" backplane/pgformatter -i queries.sql
-	docker run --rm --volume "$$(pwd)/sqlc/queries-oidc.sql:/work/queries.sql" backplane/pgformatter -i queries.sql
-	docker run --rm --volume "$$(pwd)/sqlc/queries-scim.sql:/work/queries.sql" backplane/pgformatter -i queries.sql
-	docker run --rm --volume "$$(pwd)/sqlc/queries-common.sql:/work/queries.sql" backplane/pgformatter -i queries.sql
-	docker run --rm --volume "$$(pwd)/sqlc/queries-wellknown.sql:/work/queries.sql" backplane/pgformatter -i queries.sql
-	docker run --rm --volume "$$(pwd)/sqlc/queries-configapi.sql:/work/queries.sql" backplane/pgformatter -i queries.sql
+	rm -rf \
+		internal/store/queries \
+		internal/auditlog/store/queries \
+		internal/backend/store/queries \
+		internal/frontend/store/queries \
+		internal/intermediate/store/queries \
+		internal/saml/store/queries \
+		internal/oidc/store/queries \
+		internal/scim/store/queries \
+		internal/common/store/queries \
+		internal/wellknown/store/queries \
+		internal/configapi/store/queries
+	./bin/pg_format/pg_format -i sqlc/queries.sql
+	./bin/pg_format/pg_format -i sqlc/queries-auditlog.sql
+	./bin/pg_format/pg_format -i sqlc/queries-backend.sql
+	./bin/pg_format/pg_format -i sqlc/queries-frontend.sql
+	./bin/pg_format/pg_format -i sqlc/queries-intermediate.sql
+	./bin/pg_format/pg_format -i sqlc/queries-saml.sql
+	./bin/pg_format/pg_format -i sqlc/queries-oidc.sql
+	./bin/pg_format/pg_format -i sqlc/queries-scim.sql
+	./bin/pg_format/pg_format -i sqlc/queries-common.sql
+	./bin/pg_format/pg_format -i sqlc/queries-wellknown.sql
+	./bin/pg_format/pg_format -i sqlc/queries-configapi.sql
 	sqlc -f ./sqlc/sqlc.yaml generate

--- a/bin/pg_format/Dockerfile
+++ b/bin/pg_format/Dockerfile
@@ -1,0 +1,25 @@
+FROM perl:5.40-slim
+
+ARG CHARSET=UTF-8
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        git \
+        make && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /usr/src/
+
+RUN git clone https://github.com/darold/pgFormatter.git
+
+WORKDIR /usr/src/pgFormatter
+
+RUN perl Makefile.PL && \
+    make && \
+    make install
+
+VOLUME ["/work"]
+WORKDIR /work
+
+ENTRYPOINT ["/usr/local/bin/pg_format"]
+CMD ["--help"]

--- a/bin/pg_format/pg_format
+++ b/bin/pg_format/pg_format
@@ -1,0 +1,26 @@
+#!/bin/bash
+#
+# Wrapper script to run pgFormatter via Docker.
+#
+# This script checks if the pgformatter:local Docker image exists.
+# If not, it builds the image from a Dockerfile in the current directory.
+# It then runs the container, passing all script arguments directly to the
+# pg_format command inside the container.
+
+set -eu
+
+IMAGE_NAME="pgformatter:local"
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+if ! docker image inspect "${IMAGE_NAME}" &> /dev/null; then
+    if ! docker build -t "${IMAGE_NAME}" "${DIR}"; then
+        echo "Error: Docker image build failed." >&2
+        exit 1
+    fi
+fi
+
+docker run \
+    --rm \
+    -v "$(pwd)":/work \
+    -w /work \
+    "${IMAGE_NAME}" "$@"


### PR DESCRIPTION
The latest Docker image for pgformatter is broken, due to Perl 5.42 changes.

This commit:

- Vends our own pgformatter Docker image using Perl 5.40
- Adds a pg_format script to run it
- Updates GitHub Actions workflow to use the new script