### PR TITLE
Add cascade delete constraints to OIDC connections and intermediate sessions

### DIFF
--- a/cmd/openauthctl/migrations/000085_oidc_connections_cascade_delete.up.sql
+++ b/cmd/openauthctl/migrations/000085_oidc_connections_cascade_delete.up.sql
@@ -1,0 +1,7 @@
+ALTER TABLE oidc_connections DROP CONSTRAINT oidc_connections_organization_id_fkey;
+ALTER TABLE oidc_connections ADD CONSTRAINT oidc_connections_organization_id_fkey
+    FOREIGN KEY (organization_id) REFERENCES organizations(id) ON DELETE CASCADE;
+
+ALTER TABLE oidc_intermediate_sessions DROP CONSTRAINT oidc_intermediate_sessions_oidc_connection_id_fkey;
+ALTER TABLE oidc_intermediate_sessions ADD CONSTRAINT oidc_intermediate_sessions_oidc_connection_id_fkey
+    FOREIGN KEY (oidc_connection_id) REFERENCES oidc_connections(id) ON DELETE CASCADE;


### PR DESCRIPTION
Miss from #489. I copied the original SAML connections migration without seeing the cascade deletes added in a subsequent migration.