### PR TITLE
[OPEN-512] Video fallback for SAML setup wizard

### DIFF
--- a/vault-ui/src/components/saml-connections/SetupWizardVideo.tsx
+++ b/vault-ui/src/components/saml-connections/SetupWizardVideo.tsx
@@ -3,7 +3,7 @@ import React, { useState } from "react";
 
 import { Skeleton } from "@/components/ui/skeleton";
 
-export default function SetupWizardVideo({
+export function SetupWizardVideo({
   src,
   width = 1144,
   height = 720,

--- a/vault-ui/src/components/saml-connections/SetupWizardVideo.tsx
+++ b/vault-ui/src/components/saml-connections/SetupWizardVideo.tsx
@@ -1,0 +1,33 @@
+import clsx from "clsx";
+import React, { useState } from "react";
+
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function SetupWizardVideo({
+  src,
+  width = 1144,
+  height = 720,
+}: {
+  src: string;
+  width?: number;
+  height?: number;
+}) {
+  const [loaded, setLoaded] = useState(false);
+  const aspectRatio = `${width}/${height}`;
+
+  return (
+    <div className="relative w-full" style={{ aspectRatio }}>
+      {!loaded && (
+        <Skeleton className="rounded-xl border shadow-md w-full h-full absolute top-0 left-0" />
+      )}
+      <img
+        className={clsx(
+          "rounded-xl border shadow-md w-full h-full object-cover",
+          { hidden: !loaded },
+        )}
+        src={src}
+        onLoad={() => setLoaded(true)}
+      />
+    </div>
+  );
+}

--- a/vault-ui/src/components/saml-connections/SetupWizardVideo.tsx
+++ b/vault-ui/src/components/saml-connections/SetupWizardVideo.tsx
@@ -3,16 +3,11 @@ import React, { useState } from "react";
 
 import { Skeleton } from "@/components/ui/skeleton";
 
-export function SetupWizardVideo({
-  src,
-  width = 1144,
-  height = 720,
-}: {
-  src: string;
-  width?: number;
-  height?: number;
-}) {
+export function SetupWizardVideo({ src }: { src: string }) {
   const [loaded, setLoaded] = useState(false);
+
+  const width = 1144;
+  const height = 720;
   const aspectRatio = `${width}/${height}`;
 
   return (

--- a/vault-ui/src/components/saml-connections/entra/AssignEntraSamlUsers.tsx
+++ b/vault-ui/src/components/saml-connections/entra/AssignEntraSamlUsers.tsx
@@ -4,7 +4,7 @@ import { Link, useParams } from "react-router";
 import { Button } from "@/components/ui/button";
 import { DialogFooter } from "@/components/ui/dialog";
 
-import SetupWizardVideo from "../SetupWizardVideo";
+import { SetupWizardVideo } from "../SetupWizardVideo";
 
 export function AssignEntraSamlUsers() {
   const { samlConnectionId } = useParams();

--- a/vault-ui/src/components/saml-connections/entra/AssignEntraSamlUsers.tsx
+++ b/vault-ui/src/components/saml-connections/entra/AssignEntraSamlUsers.tsx
@@ -4,16 +4,15 @@ import { Link, useParams } from "react-router";
 import { Button } from "@/components/ui/button";
 import { DialogFooter } from "@/components/ui/dialog";
 
+import SetupWizardVideo from "../SetupWizardVideo";
+
 export function AssignEntraSamlUsers() {
   const { samlConnectionId } = useParams();
 
   return (
     <>
       <div className="space-y-4 text-sm">
-        <img
-          className="rounded-xl max-w-full border shadow-md"
-          src="/videos/saml-setup-wizard/entra/users.gif"
-        />
+        <SetupWizardVideo src="/videos/saml-setup-wizard/entra/users.gif" />
 
         <p className="font-medium">Assign users to the new app.</p>
         <p>

--- a/vault-ui/src/components/saml-connections/entra/ConfigureEntraSamlIdentifier.tsx
+++ b/vault-ui/src/components/saml-connections/entra/ConfigureEntraSamlIdentifier.tsx
@@ -7,7 +7,7 @@ import { Button } from "@/components/ui/button";
 import { DialogFooter } from "@/components/ui/dialog";
 import { getSAMLConnection } from "@/gen/tesseral/frontend/v1/frontend-FrontendService_connectquery";
 
-import SetupWizardVideo from "../SetupWizardVideo";
+import { SetupWizardVideo } from "../SetupWizardVideo";
 
 export function ConfigureEntraSamlIdentifier() {
   const { samlConnectionId } = useParams();

--- a/vault-ui/src/components/saml-connections/entra/ConfigureEntraSamlIdentifier.tsx
+++ b/vault-ui/src/components/saml-connections/entra/ConfigureEntraSamlIdentifier.tsx
@@ -7,6 +7,8 @@ import { Button } from "@/components/ui/button";
 import { DialogFooter } from "@/components/ui/dialog";
 import { getSAMLConnection } from "@/gen/tesseral/frontend/v1/frontend-FrontendService_connectquery";
 
+import SetupWizardVideo from "../SetupWizardVideo";
+
 export function ConfigureEntraSamlIdentifier() {
   const { samlConnectionId } = useParams();
   const { data: getSamlConnectionResponse } = useQuery(getSAMLConnection, {
@@ -18,10 +20,7 @@ export function ConfigureEntraSamlIdentifier() {
   return (
     <>
       <div className="space-y-4 text-sm">
-        <img
-          className="rounded-xl max-w-full border shadow-md"
-          src="/videos/saml-setup-wizard/entra/identifier.gif"
-        />
+        <SetupWizardVideo src="/videos/saml-setup-wizard/entra/identifier.gif" />
 
         <p className="font-medium">Configure SAML Identifier (Entity ID)</p>
         <ol className="list-decimal list-inside space-y-2">

--- a/vault-ui/src/components/saml-connections/entra/ConfigureEntraSamlReplyUrl.tsx
+++ b/vault-ui/src/components/saml-connections/entra/ConfigureEntraSamlReplyUrl.tsx
@@ -7,7 +7,7 @@ import { Button } from "@/components/ui/button";
 import { DialogFooter } from "@/components/ui/dialog";
 import { getSAMLConnection } from "@/gen/tesseral/frontend/v1/frontend-FrontendService_connectquery";
 
-import SetupWizardVideo from "../SetupWizardVideo";
+import { SetupWizardVideo } from "../SetupWizardVideo";
 
 export function ConfigureEntraSamlReplyUrl() {
   const { samlConnectionId } = useParams();

--- a/vault-ui/src/components/saml-connections/entra/ConfigureEntraSamlReplyUrl.tsx
+++ b/vault-ui/src/components/saml-connections/entra/ConfigureEntraSamlReplyUrl.tsx
@@ -7,6 +7,8 @@ import { Button } from "@/components/ui/button";
 import { DialogFooter } from "@/components/ui/dialog";
 import { getSAMLConnection } from "@/gen/tesseral/frontend/v1/frontend-FrontendService_connectquery";
 
+import SetupWizardVideo from "../SetupWizardVideo";
+
 export function ConfigureEntraSamlReplyUrl() {
   const { samlConnectionId } = useParams();
   const { data: getSamlConnectionResponse } = useQuery(getSAMLConnection, {
@@ -18,10 +20,7 @@ export function ConfigureEntraSamlReplyUrl() {
   return (
     <>
       <div className="space-y-4 text-sm">
-        <img
-          className="rounded-xl max-w-full border shadow-md"
-          src="/videos/saml-setup-wizard/entra/reply-url.gif"
-        />
+        <SetupWizardVideo src="/videos/saml-setup-wizard/entra/reply-url.gif" />
 
         <p className="font-medium">
           Configure SAML Reply URL (Assertion Consumer Service URL)

--- a/vault-ui/src/components/saml-connections/entra/CreateEntraSamlApplication.tsx
+++ b/vault-ui/src/components/saml-connections/entra/CreateEntraSamlApplication.tsx
@@ -4,17 +4,15 @@ import { Link, useParams } from "react-router";
 import { Button } from "@/components/ui/button";
 import { DialogFooter } from "@/components/ui/dialog";
 
+import SetupWizardVideo from "../SetupWizardVideo";
+
 export function CreateEntraSamlApplication() {
   const { samlConnectionId } = useParams();
 
   return (
     <>
       <div className="space-y-4 text-sm">
-        <img
-          className="rounded-xl max-w-full border shadow-md"
-          src="/videos/saml-setup-wizard/entra/create.gif"
-        />
-
+        <SetupWizardVideo src="/videos/saml-setup-wizard/entra/create.gif" />
         <p className="font-medium">Create a new Entra SAML application:</p>
         <ol className="list-decimal list-inside space-y-2">
           <li>

--- a/vault-ui/src/components/saml-connections/entra/CreateEntraSamlApplication.tsx
+++ b/vault-ui/src/components/saml-connections/entra/CreateEntraSamlApplication.tsx
@@ -4,7 +4,7 @@ import { Link, useParams } from "react-router";
 import { Button } from "@/components/ui/button";
 import { DialogFooter } from "@/components/ui/dialog";
 
-import SetupWizardVideo from "../SetupWizardVideo";
+import { SetupWizardVideo } from "../SetupWizardVideo";
 
 export function CreateEntraSamlApplication() {
   const { samlConnectionId } = useParams();

--- a/vault-ui/src/components/saml-connections/entra/DownloadEntraSamlMetadata.tsx
+++ b/vault-ui/src/components/saml-connections/entra/DownloadEntraSamlMetadata.tsx
@@ -24,6 +24,8 @@ import {
 } from "@/gen/tesseral/frontend/v1/frontend-FrontendService_connectquery";
 import { SAMLMetadata, parseSamlMetadata } from "@/lib/saml";
 
+import SetupWizardVideo from "../SetupWizardVideo";
+
 const schema = z.object({
   entraSamlMetadata: z.string(),
 });
@@ -115,10 +117,7 @@ export function DownloadEntraSamlMetadata() {
   return (
     <>
       <div className="space-y-4 text-sm">
-        <img
-          className="rounded-xl max-w-full border shadow-md"
-          src="/videos/saml-setup-wizard/entra/metadata.gif"
-        />
+        <SetupWizardVideo src="/videos/saml-setup-wizard/entra/metadata.gif" />
 
         <p className="font-medium">
           Download your application's Federation Metadata XML:

--- a/vault-ui/src/components/saml-connections/entra/DownloadEntraSamlMetadata.tsx
+++ b/vault-ui/src/components/saml-connections/entra/DownloadEntraSamlMetadata.tsx
@@ -24,7 +24,7 @@ import {
 } from "@/gen/tesseral/frontend/v1/frontend-FrontendService_connectquery";
 import { SAMLMetadata, parseSamlMetadata } from "@/lib/saml";
 
-import SetupWizardVideo from "../SetupWizardVideo";
+import { SetupWizardVideo } from "../SetupWizardVideo";
 
 const schema = z.object({
   entraSamlMetadata: z.string(),

--- a/vault-ui/src/components/saml-connections/google/AssignGoogleSamlUsers.tsx
+++ b/vault-ui/src/components/saml-connections/google/AssignGoogleSamlUsers.tsx
@@ -4,16 +4,15 @@ import { Link, useParams } from "react-router";
 import { Button } from "@/components/ui/button";
 import { DialogFooter } from "@/components/ui/dialog";
 
+import SetupWizardVideo from "../SetupWizardVideo";
+
 export function AssignGoogleSamlUsers() {
   const { samlConnectionId } = useParams();
 
   return (
     <>
       <div className="space-y-4 text-sm">
-        <img
-          className="rounded-xl max-w-full border shadow-md"
-          src="/videos/saml-setup-wizard/google/users.gif"
-        />
+        <SetupWizardVideo src="/videos/saml-setup-wizard/google/users.gif" />
 
         <p className="font-medium">Assign users to the new app.</p>
         <p>

--- a/vault-ui/src/components/saml-connections/google/AssignGoogleSamlUsers.tsx
+++ b/vault-ui/src/components/saml-connections/google/AssignGoogleSamlUsers.tsx
@@ -4,7 +4,7 @@ import { Link, useParams } from "react-router";
 import { Button } from "@/components/ui/button";
 import { DialogFooter } from "@/components/ui/dialog";
 
-import SetupWizardVideo from "../SetupWizardVideo";
+import { SetupWizardVideo } from "../SetupWizardVideo";
 
 export function AssignGoogleSamlUsers() {
   const { samlConnectionId } = useParams();

--- a/vault-ui/src/components/saml-connections/google/ConfigureGoogleSamlApplication.tsx
+++ b/vault-ui/src/components/saml-connections/google/ConfigureGoogleSamlApplication.tsx
@@ -9,7 +9,7 @@ import { DialogFooter } from "@/components/ui/dialog";
 import { Label } from "@/components/ui/label";
 import { getSAMLConnection } from "@/gen/tesseral/frontend/v1/frontend-FrontendService_connectquery";
 
-import SetupWizardVideo from "../SetupWizardVideo";
+import { SetupWizardVideo } from "../SetupWizardVideo";
 
 export function ConfigureGoogleSamlApplication() {
   const { samlConnectionId } = useParams();

--- a/vault-ui/src/components/saml-connections/google/ConfigureGoogleSamlApplication.tsx
+++ b/vault-ui/src/components/saml-connections/google/ConfigureGoogleSamlApplication.tsx
@@ -9,6 +9,8 @@ import { DialogFooter } from "@/components/ui/dialog";
 import { Label } from "@/components/ui/label";
 import { getSAMLConnection } from "@/gen/tesseral/frontend/v1/frontend-FrontendService_connectquery";
 
+import SetupWizardVideo from "../SetupWizardVideo";
+
 export function ConfigureGoogleSamlApplication() {
   const { samlConnectionId } = useParams();
 
@@ -24,10 +26,7 @@ export function ConfigureGoogleSamlApplication() {
   return (
     <>
       <div className="text-sm space-y-4">
-        <img
-          className="rounded-xl max-w-full border shadow-md"
-          src="/videos/saml-setup-wizard/google/configure.gif"
-        />
+        <SetupWizardVideo src="/videos/saml-setup-wizard/google/configure.gif" />
 
         <p className="font-medium">Configure your Google SAML application:</p>
         <ol className="list-decimal pl-6">

--- a/vault-ui/src/components/saml-connections/google/CreateGoogleSamlApplication.tsx
+++ b/vault-ui/src/components/saml-connections/google/CreateGoogleSamlApplication.tsx
@@ -4,15 +4,14 @@ import { Link, useParams } from "react-router";
 import { Button } from "@/components/ui/button";
 import { DialogFooter } from "@/components/ui/dialog";
 
+import SetupWizardVideo from "../SetupWizardVideo";
+
 export function CreateGoogleSamlApplication() {
   const { samlConnectionId } = useParams();
   return (
     <>
       <div className="space-y-4 text-sm">
-        <img
-          className="rounded-xl max-w-full border shadow-md"
-          src="/videos/saml-setup-wizard/google/create.gif"
-        />
+        <SetupWizardVideo src="/videos/saml-setup-wizard/google/create.gif" />
 
         <p className="font-medium">Create a new Google SAML application:</p>
         <ol className="list-decimal list-inside space-y-2">

--- a/vault-ui/src/components/saml-connections/google/CreateGoogleSamlApplication.tsx
+++ b/vault-ui/src/components/saml-connections/google/CreateGoogleSamlApplication.tsx
@@ -4,7 +4,7 @@ import { Link, useParams } from "react-router";
 import { Button } from "@/components/ui/button";
 import { DialogFooter } from "@/components/ui/dialog";
 
-import SetupWizardVideo from "../SetupWizardVideo";
+import { SetupWizardVideo } from "../SetupWizardVideo";
 
 export function CreateGoogleSamlApplication() {
   const { samlConnectionId } = useParams();

--- a/vault-ui/src/components/saml-connections/google/DownloadGoogleSamlMetadata.tsx
+++ b/vault-ui/src/components/saml-connections/google/DownloadGoogleSamlMetadata.tsx
@@ -24,6 +24,8 @@ import {
 } from "@/gen/tesseral/frontend/v1/frontend-FrontendService_connectquery";
 import { SAMLMetadata, parseSamlMetadata } from "@/lib/saml";
 
+import SetupWizardVideo from "../SetupWizardVideo";
+
 const schema = z.object({
   googleSamlMetadata: z.string(),
 });
@@ -122,10 +124,7 @@ export function DownloadGoogleSamlMetadata() {
   return (
     <>
       <div className="space-y-4 text-sm">
-        <img
-          className="rounded-xl max-w-full border shadow-md"
-          src="/videos/saml-setup-wizard/google/metadata.gif"
-        />
+        <SetupWizardVideo src="/videos/saml-setup-wizard/google/metadata.gif" />
 
         <p className="font-medium">Download IdP metadata:</p>
 

--- a/vault-ui/src/components/saml-connections/google/DownloadGoogleSamlMetadata.tsx
+++ b/vault-ui/src/components/saml-connections/google/DownloadGoogleSamlMetadata.tsx
@@ -24,7 +24,7 @@ import {
 } from "@/gen/tesseral/frontend/v1/frontend-FrontendService_connectquery";
 import { SAMLMetadata, parseSamlMetadata } from "@/lib/saml";
 
-import SetupWizardVideo from "../SetupWizardVideo";
+import { SetupWizardVideo } from "../SetupWizardVideo";
 
 const schema = z.object({
   googleSamlMetadata: z.string(),

--- a/vault-ui/src/components/saml-connections/google/NameGoogleSamlApplication.tsx
+++ b/vault-ui/src/components/saml-connections/google/NameGoogleSamlApplication.tsx
@@ -4,15 +4,14 @@ import { Link, useParams } from "react-router";
 import { Button } from "@/components/ui/button";
 import { DialogFooter } from "@/components/ui/dialog";
 
+import SetupWizardVideo from "../SetupWizardVideo";
+
 export function NameGoogleSamlApplication() {
   const { samlConnectionId } = useParams();
   return (
     <>
       <div className="space-y-4 text-sm">
-        <img
-          className="rounded-xl max-w-full border shadow-md"
-          src="/videos/saml-setup-wizard/google/name.gif"
-        />
+        <SetupWizardVideo src="/videos/saml-setup-wizard/google/name.gif" />
 
         <p className="font-medium">Name your Google SAML application:</p>
         <ol className="list-decimal list-inside space-y-2">

--- a/vault-ui/src/components/saml-connections/google/NameGoogleSamlApplication.tsx
+++ b/vault-ui/src/components/saml-connections/google/NameGoogleSamlApplication.tsx
@@ -4,7 +4,7 @@ import { Link, useParams } from "react-router";
 import { Button } from "@/components/ui/button";
 import { DialogFooter } from "@/components/ui/dialog";
 
-import SetupWizardVideo from "../SetupWizardVideo";
+import { SetupWizardVideo } from "../SetupWizardVideo";
 
 export function NameGoogleSamlApplication() {
   const { samlConnectionId } = useParams();

--- a/vault-ui/src/components/saml-connections/okta/AssignOktaSamlUsers.tsx
+++ b/vault-ui/src/components/saml-connections/okta/AssignOktaSamlUsers.tsx
@@ -4,16 +4,15 @@ import { Link, useParams } from "react-router";
 import { Button } from "@/components/ui/button";
 import { DialogFooter } from "@/components/ui/dialog";
 
+import SetupWizardVideo from "../SetupWizardVideo";
+
 export function AssignOktaSamlUsers() {
   const { samlConnectionId } = useParams();
 
   return (
     <>
       <div className="space-y-4 text-sm">
-        <img
-          className="rounded-xl max-w-full border shadow-md"
-          src="/videos/saml-setup-wizard/okta/users.gif"
-        />
+        <SetupWizardVideo src="/videos/saml-setup-wizard/okta/users.gif" />
 
         <p className="font-medium">Assign users to the new app.</p>
         <p>

--- a/vault-ui/src/components/saml-connections/okta/AssignOktaSamlUsers.tsx
+++ b/vault-ui/src/components/saml-connections/okta/AssignOktaSamlUsers.tsx
@@ -4,7 +4,7 @@ import { Link, useParams } from "react-router";
 import { Button } from "@/components/ui/button";
 import { DialogFooter } from "@/components/ui/dialog";
 
-import SetupWizardVideo from "../SetupWizardVideo";
+import { SetupWizardVideo } from "../SetupWizardVideo";
 
 export function AssignOktaSamlUsers() {
   const { samlConnectionId } = useParams();

--- a/vault-ui/src/components/saml-connections/okta/ConfigureOktaSamlApplication.tsx
+++ b/vault-ui/src/components/saml-connections/okta/ConfigureOktaSamlApplication.tsx
@@ -7,7 +7,7 @@ import { Button } from "@/components/ui/button";
 import { DialogFooter } from "@/components/ui/dialog";
 import { getSAMLConnection } from "@/gen/tesseral/frontend/v1/frontend-FrontendService_connectquery";
 
-import SetupWizardVideo from "../SetupWizardVideo";
+import { SetupWizardVideo } from "../SetupWizardVideo";
 
 export function ConfigureOktaSamlApplication() {
   const { samlConnectionId } = useParams();

--- a/vault-ui/src/components/saml-connections/okta/ConfigureOktaSamlApplication.tsx
+++ b/vault-ui/src/components/saml-connections/okta/ConfigureOktaSamlApplication.tsx
@@ -7,6 +7,8 @@ import { Button } from "@/components/ui/button";
 import { DialogFooter } from "@/components/ui/dialog";
 import { getSAMLConnection } from "@/gen/tesseral/frontend/v1/frontend-FrontendService_connectquery";
 
+import SetupWizardVideo from "../SetupWizardVideo";
+
 export function ConfigureOktaSamlApplication() {
   const { samlConnectionId } = useParams();
   const { data: getSamlConnectionResponse } = useQuery(getSAMLConnection, {
@@ -18,10 +20,7 @@ export function ConfigureOktaSamlApplication() {
   return (
     <>
       <div className="space-y-4 text-sm">
-        <img
-          className="rounded-xl max-w-full border shadow-md"
-          src="/videos/saml-setup-wizard/okta/configure.gif"
-        />
+        <SetupWizardVideo src="/videos/saml-setup-wizard/okta/configure.gif" />
 
         <p className="font-medium">Create your Okta SAML application:</p>
         <ol className="list-decimal list-inside space-y-2">

--- a/vault-ui/src/components/saml-connections/okta/CreateOktaSamlApplication.tsx
+++ b/vault-ui/src/components/saml-connections/okta/CreateOktaSamlApplication.tsx
@@ -4,7 +4,7 @@ import { Link, useParams } from "react-router";
 import { Button } from "@/components/ui/button";
 import { DialogFooter } from "@/components/ui/dialog";
 
-import SetupWizardVideo from "../SetupWizardVideo";
+import { SetupWizardVideo } from "../SetupWizardVideo";
 
 export function CreateOktaSamlApplication() {
   const { samlConnectionId } = useParams();

--- a/vault-ui/src/components/saml-connections/okta/CreateOktaSamlApplication.tsx
+++ b/vault-ui/src/components/saml-connections/okta/CreateOktaSamlApplication.tsx
@@ -4,15 +4,14 @@ import { Link, useParams } from "react-router";
 import { Button } from "@/components/ui/button";
 import { DialogFooter } from "@/components/ui/dialog";
 
+import SetupWizardVideo from "../SetupWizardVideo";
+
 export function CreateOktaSamlApplication() {
   const { samlConnectionId } = useParams();
   return (
     <>
       <div className="space-y-4 text-sm">
-        <img
-          className="rounded-xl max-w-full border shadow-md"
-          src="/videos/saml-setup-wizard/okta/create.gif"
-        />
+        <SetupWizardVideo src="/videos/saml-setup-wizard/okta/create.gif" />
 
         <p className="font-medium">Create your Okta SAML application:</p>
         <ol className="list-decimal list-inside space-y-2">

--- a/vault-ui/src/components/saml-connections/okta/NameOktaSamlApplication.tsx
+++ b/vault-ui/src/components/saml-connections/okta/NameOktaSamlApplication.tsx
@@ -4,15 +4,14 @@ import { Link, useParams } from "react-router";
 import { Button } from "@/components/ui/button";
 import { DialogFooter } from "@/components/ui/dialog";
 
+import SetupWizardVideo from "../SetupWizardVideo";
+
 export function NameOktaSamlApplication() {
   const { samlConnectionId } = useParams();
   return (
     <>
       <div className="space-y-4 text-sm">
-        <img
-          className="rounded-xl max-w-full border shadow-md"
-          src="/videos/saml-setup-wizard/okta/name.gif"
-        />
+        <SetupWizardVideo src="/videos/saml-setup-wizard/okta/name.gif" />
 
         <p className="font-medium">Name your Okta SAML application:</p>
         <ol className="list-decimal list-inside space-y-2">

--- a/vault-ui/src/components/saml-connections/okta/NameOktaSamlApplication.tsx
+++ b/vault-ui/src/components/saml-connections/okta/NameOktaSamlApplication.tsx
@@ -4,7 +4,7 @@ import { Link, useParams } from "react-router";
 import { Button } from "@/components/ui/button";
 import { DialogFooter } from "@/components/ui/dialog";
 
-import SetupWizardVideo from "../SetupWizardVideo";
+import { SetupWizardVideo } from "../SetupWizardVideo";
 
 export function NameOktaSamlApplication() {
   const { samlConnectionId } = useParams();

--- a/vault-ui/src/components/saml-connections/okta/SyncOktaSamlMetadata.tsx
+++ b/vault-ui/src/components/saml-connections/okta/SyncOktaSamlMetadata.tsx
@@ -23,6 +23,8 @@ import {
   updateSAMLConnection,
 } from "@/gen/tesseral/frontend/v1/frontend-FrontendService_connectquery";
 
+import SetupWizardVideo from "../SetupWizardVideo";
+
 interface OktaMetadata {
   idpEntityId: string;
   idpRedirectUrl: string;
@@ -131,10 +133,7 @@ export function SyncOktaSamlMetadata() {
   return (
     <>
       <div className="space-y-4 text-sm">
-        <img
-          className="rounded-xl max-w-full border shadow-md"
-          src="/videos/saml-setup-wizard/okta/metadata.gif"
-        />
+        <SetupWizardVideo src="/videos/saml-setup-wizard/okta/metadata.gif" />
 
         <p className="font-medium">Create your Okta SAML application:</p>
         <ol className="list-decimal list-inside space-y-2">

--- a/vault-ui/src/components/saml-connections/okta/SyncOktaSamlMetadata.tsx
+++ b/vault-ui/src/components/saml-connections/okta/SyncOktaSamlMetadata.tsx
@@ -23,7 +23,7 @@ import {
   updateSAMLConnection,
 } from "@/gen/tesseral/frontend/v1/frontend-FrontendService_connectquery";
 
-import SetupWizardVideo from "../SetupWizardVideo";
+import { SetupWizardVideo } from "../SetupWizardVideo";
 
 interface OktaMetadata {
   idpEntityId: string;


### PR DESCRIPTION
Uses the `Skeleton` component to display a loading tile for SAML Setup Wizard videos.

Shown here with artificial delay:

https://github.com/user-attachments/assets/ed866f42-12df-441e-a194-d00ed31034ed


