### PR TITLE
No "signup" subtitle if self-serve user creation disabled

### DIFF
--- a/vault-ui/src/pages/login/LoginPage.tsx
+++ b/vault-ui/src/pages/login/LoginPage.tsx
@@ -430,15 +430,17 @@ function LoginPageContents() {
         </CardContent>
       </LoginFlowCard>
 
-      <p className="text-center mt-4 text-xs text-muted-foreground">
-        Don't have an account?{" "}
-        <Link
-          to={`/signup${serializedQueryParamState}`}
-          className="cursor-pointer text-foreground underline underline-offset-2 decoration-muted-foreground"
-        >
-          Sign up.
-        </Link>
-      </p>
+      {settings.selfServeCreateUsers && (
+        <p className="text-center mt-4 text-xs text-muted-foreground">
+          Don't have an account?{" "}
+          <Link
+            to={`/signup${serializedQueryParamState}`}
+            className="cursor-pointer text-foreground underline underline-offset-2 decoration-muted-foreground"
+          >
+            Sign up.
+          </Link>
+        </p>
+      )}
     </>
   );
 }


### PR DESCRIPTION
<img width="529" alt="Screenshot 2025-07-09 at 3 28 03 PM" src="https://github.com/user-attachments/assets/e26f9a33-9a88-4d34-bc0c-826f072108ab" />

(The point of the screenshot is that there's nothing there below the card.)