### PR TITLE
Add remote debugging configuration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,10 @@ bootstrap:
 dev:
 	docker compose up --build --watch
 
+.PHONY: debug
+debug:
+	docker compose --project-name=tesseral-debug --file=docker-compose.debug.yaml up --build --watch
+
 .PHONY: migrate
 ARGS = $(wordlist 2, $(words $(MAKECMDGOALS)), $(MAKECMDGOALS))
 migrate:

--- a/cmd/api/Dockerfile.debug
+++ b/cmd/api/Dockerfile.debug
@@ -1,0 +1,24 @@
+FROM --platform=$BUILDPLATFORM golang:1.24
+
+ARG TARGETOS
+ARG TARGETARCH
+
+RUN apt update && apt install -y git ca-certificates tzdata && update-ca-certificates
+
+# Build Delve
+RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go install -ldflags "-s -w -extldflags '-static'" github.com/go-delve/delve/cmd/dlv@latest
+
+WORKDIR /work
+
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY cmd ./cmd
+COPY internal ./internal
+
+RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -gcflags "all=-N -l" -o api ./cmd/api
+
+EXPOSE 40000
+EXPOSE 3001
+
+ENTRYPOINT ["/go/bin/dlv", "--listen=:40000", "--headless=true", "--api-version=2", "--accept-multiclient", "exec", "/work/api"]

--- a/cmd/api/Dockerfile.debug
+++ b/cmd/api/Dockerfile.debug
@@ -1,8 +1,5 @@
 FROM --platform=$BUILDPLATFORM golang:1.24
 
-ARG TARGETOS
-ARG TARGETARCH
-
 RUN apt update && apt install -y git ca-certificates tzdata && update-ca-certificates
 
 # Build Delve

--- a/cmd/api/Dockerfile.debug
+++ b/cmd/api/Dockerfile.debug
@@ -6,7 +6,7 @@ ARG TARGETARCH
 RUN apt update && apt install -y git ca-certificates tzdata && update-ca-certificates
 
 # Build Delve
-RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go install -ldflags "-s -w -extldflags '-static'" github.com/go-delve/delve/cmd/dlv@latest
+RUN go install github.com/go-delve/delve/cmd/dlv@latest
 
 WORKDIR /work
 
@@ -16,7 +16,7 @@ RUN go mod download
 COPY cmd ./cmd
 COPY internal ./internal
 
-RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -gcflags "all=-N -l" -o api ./cmd/api
+RUN CGO_ENABLED=0 go build -gcflags "all=-N -l" -o api ./cmd/api
 
 EXPOSE 40000
 EXPOSE 3001

--- a/docker-compose.debug.yaml
+++ b/docker-compose.debug.yaml
@@ -1,0 +1,113 @@
+services:
+  api:
+    build:
+      dockerfile: ./cmd/api/Dockerfile.debug
+      context: .
+    develop:
+      watch:
+        - action: rebuild
+          path: ./cmd/api/
+        - action: rebuild
+          path: ./internal/
+    depends_on:
+      postgres:
+        condition: service_healthy
+    environment:
+      API_DB_DSN: "postgres://postgres:password@postgres:5432/postgres"
+    env_file:
+      - .env
+    ports:
+      - "3001:3001"
+      - "40000:40000"
+    tty: true
+    cap_add:
+      - SYS_PTRACE
+    security_opt:
+      - apparmor=unconfined
+  console:
+    command: bash -c "npm i --force && npm run dev"
+    env_file:
+      - .env
+    expose:
+      - 3000
+    image: node:22.11.0
+    ports:
+      - "3000:3000"
+    tty: true
+    volumes:
+      - ./console:/console:cached
+    working_dir: /console
+  kms:
+    environment:
+      KMS_REGION: ${AWS_DEFAULT_REGION}
+      PORT: 4566
+    expose:
+      - 4566
+    image: nsmithuk/local-kms:latest
+    ports:
+      - 4566:4566
+      - 4599:4566
+    volumes:
+      - ./.local/kms/data/:/data/
+      - ./.local/kms/seed.yaml:/init/seed.yaml
+  nginx:
+    image: nginx:1
+    ports:
+      - "80:80"
+      - "443:443"
+    restart: always
+    volumes:
+      - ./.local/nginx:/etc/nginx/conf.d
+  postgres:
+    image: postgres:15.8
+    environment:
+      POSTGRES_PASSWORD: "password"
+    expose:
+      - 5432
+    ports:
+      - "5432:5432"
+    healthcheck:
+      test:
+        ["CMD-SHELL", "PGPASSWORD=password pg_isready -U postgres -d postgres"]
+      interval: 10s
+      retries: 5
+      start_period: 30s
+      timeout: 10s
+    volumes:
+      - ./.local/postgres:/var/lib/postgresql/data
+      - ./.local/tmp:/tmp/local
+  s3:
+    image: adobe/s3mock:latest
+    environment:
+      - initialBuckets=tesseral-user-content
+      - root=containers3root
+      - retainFilesOnExit=true
+    ports:
+      - 9090:9090
+    volumes:
+      - ./.local/s3:/containers3root
+  ses:
+    build:
+      dockerfile: ./.local/ses/Dockerfile
+      context: .
+    environment:
+      AWS_SES_ACCOUNT: ${AWS_SES_ACCOUNT}
+      SMTP_TRANSPORT: ${SMTP_TRANSPORT}
+    working_dir: /srv/www/dist
+    ports:
+      - 8005:8005
+    volumes:
+      - ./.local/ses/output:/output
+  vault-ui:
+    command: bash -c "npm i --force && npm run dev"
+    environment:
+      UI_BUILD_IS_DEV: 1
+    expose:
+      - 3002
+    image: node:22.11.0
+    ports:
+      - "3002:3002"
+    tty: true
+    volumes:
+      - ./vault-ui:/vault-ui:cached
+    working_dir: /vault-ui


### PR DESCRIPTION
To improve DX when developing Tesseral, this introduces a separate container setup with remote debugging using Delve. Instead of `make dev`, you can now use `make debug` to spin up a debuggable Docker container.

Then, in VSCode or any other IDE, you can attach to the running Delve instance (port 40000) for debugging:

```json
{
    "version": "0.2.0",
    "configurations": [
        {
            "name": "Remote Go Debug",
            "type": "go",
            "request": "attach",
            "mode": "remote",
            "host": "127.0.0.1",
            "port": 40000,
            "debugAdapter": "dlv-dap",
            "substitutePath": [
                { "from": "${workspaceFolder}", "to": "/work" }
            ]
        }
    ]
}
```

<img width="3120" height="1779" alt="Screenshot 2025-07-11 at 12 43 04 PM" src="https://github.com/user-attachments/assets/3e3387e8-796c-49f3-9d23-a2501a4aef16" />
