### PR TITLE
Always output logs to stdout

### DIFF
--- a/cmd/api/logger.go
+++ b/cmd/api/logger.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+)
+
+type multiOutputHandler []slog.Handler
+
+func (m multiOutputHandler) Enabled(ctx context.Context, level slog.Level) bool {
+	for _, handler := range m {
+		if handler.Enabled(ctx, level) {
+			return true
+		}
+	}
+	return false
+}
+
+func (m multiOutputHandler) Handle(ctx context.Context, record slog.Record) error {
+	var errs []error
+	for _, handler := range m {
+		if handler.Enabled(ctx, record.Level) {
+			errs = append(errs, handler.Handle(ctx, record))
+		}
+	}
+	return errors.Join(errs...)
+}
+
+func (m multiOutputHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	var newHandlers []slog.Handler
+	for _, handler := range m {
+		newHandlers = append(newHandlers, handler.WithAttrs(attrs))
+	}
+	return multiOutputHandler(newHandlers)
+}
+
+func (m multiOutputHandler) WithGroup(name string) slog.Handler {
+	var newHandlers []slog.Handler
+	for _, handler := range m {
+		newHandlers = append(newHandlers, handler.WithGroup(name))
+	}
+	return multiOutputHandler(newHandlers)
+}

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -89,10 +89,9 @@ func main() {
 		panic(fmt.Errorf("init sentry: %w", err))
 	}
 
+	jsonHandler := slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{AddSource: true})
 	slogHandler := ctxlog.NewHandler(
-		sentryintegration.NewSlogHandler(
-			slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{AddSource: true}),
-		),
+		sentryintegration.NewSlogHandler(jsonHandler),
 	)
 	slog.SetDefault(slog.New(slogHandler))
 
@@ -188,7 +187,7 @@ func main() {
 
 		slogHandler := ctxlog.NewHandler(
 			sentryintegration.NewSlogHandler(
-				otelslog.NewHandler("api"),
+				multiOutputHandler{jsonHandler, otelslog.NewHandler("api")},
 			),
 		)
 		slog.SetDefault(slog.New(slogHandler))

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -53,6 +53,7 @@ import (
 	intermediatestore "github.com/tesseral-labs/tesseral/internal/intermediate/store"
 	"github.com/tesseral-labs/tesseral/internal/loadenv"
 	"github.com/tesseral-labs/tesseral/internal/microsoftoauth"
+	"github.com/tesseral-labs/tesseral/internal/multislog"
 	oidcinterceptor "github.com/tesseral-labs/tesseral/internal/oidc/authn/interceptor"
 	oidcservice "github.com/tesseral-labs/tesseral/internal/oidc/service"
 	oidcstore "github.com/tesseral-labs/tesseral/internal/oidc/store"
@@ -187,7 +188,7 @@ func main() {
 
 		slogHandler := ctxlog.NewHandler(
 			sentryintegration.NewSlogHandler(
-				multiOutputHandler{jsonHandler, otelslog.NewHandler("api")},
+				multislog.Handler{jsonHandler, otelslog.NewHandler("api")},
 			),
 		)
 		slog.SetDefault(slog.New(slogHandler))

--- a/internal/multislog/multislog.go
+++ b/internal/multislog/multislog.go
@@ -1,4 +1,4 @@
-package main
+package multislog
 
 import (
 	"context"
@@ -6,9 +6,9 @@ import (
 	"log/slog"
 )
 
-type multiOutputHandler []slog.Handler
+type Handler []slog.Handler
 
-func (m multiOutputHandler) Enabled(ctx context.Context, level slog.Level) bool {
+func (m Handler) Enabled(ctx context.Context, level slog.Level) bool {
 	for _, handler := range m {
 		if handler.Enabled(ctx, level) {
 			return true
@@ -17,7 +17,7 @@ func (m multiOutputHandler) Enabled(ctx context.Context, level slog.Level) bool 
 	return false
 }
 
-func (m multiOutputHandler) Handle(ctx context.Context, record slog.Record) error {
+func (m Handler) Handle(ctx context.Context, record slog.Record) error {
 	var errs []error
 	for _, handler := range m {
 		if handler.Enabled(ctx, record.Level) {
@@ -27,18 +27,18 @@ func (m multiOutputHandler) Handle(ctx context.Context, record slog.Record) erro
 	return errors.Join(errs...)
 }
 
-func (m multiOutputHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+func (m Handler) WithAttrs(attrs []slog.Attr) slog.Handler {
 	var newHandlers []slog.Handler
 	for _, handler := range m {
 		newHandlers = append(newHandlers, handler.WithAttrs(attrs))
 	}
-	return multiOutputHandler(newHandlers)
+	return Handler(newHandlers)
 }
 
-func (m multiOutputHandler) WithGroup(name string) slog.Handler {
+func (m Handler) WithGroup(name string) slog.Handler {
 	var newHandlers []slog.Handler
 	for _, handler := range m {
 		newHandlers = append(newHandlers, handler.WithGroup(name))
 	}
-	return multiOutputHandler(newHandlers)
+	return Handler(newHandlers)
 }


### PR DESCRIPTION
Even when OTEL logging is enabled, we want to ensure that logs are always output to stdout.