### PR TITLE
[OPEN-587] Rename `dogfood` to `console`

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,7 +2,7 @@ API_CONSOLE_DOMAIN=console.tesseral.example.com
 API_AUTH_APPS_ROOT_DOMAIN=tesseral.example.app
 API_AUTHENTICATOR_APP_SECRETS_KMS_KEY_ID=186bf523-bc6a-479b-8ed1-e198298b98f2
 API_DB_DSN=postgres://postgres:password@0.0.0.0:5432/postgres
-API_DOGFOOD_PROJECT_ID=project_54vwf0clhh0caqe20eujxgpeq
+API_CONSOLE_PROJECT_ID=project_54vwf0clhh0caqe20eujxgpeq
 API_GITHUB_OAUTH_CLIENT_SECRETS_KMS_KEY_ID=48f79cf6-2bbd-4f65-a934-ad1df7122fbd
 API_GOOGLE_OAUTH_CLIENT_SECRETS_KMS_KEY_ID=d5670d9b-184a-400a-a08b-d05d7b99f91c
 API_KMS_ENDPOINT_RESOLVER_URL=http://kms:4566
@@ -19,7 +19,7 @@ API_USER_CONTENT_BASE_URL=https://tesseralusercontent.example.com
 
 CONSOLE_BUILD_IS_DEV=1
 CONSOLE_API_URL=https://vault.console.tesseral.example.com
-CONSOLE_DOGFOOD_PROJECT_ID=project_54vwf0clhh0caqe20eujxgpeq
+CONSOLE_CONSOLE_PROJECT_ID=project_54vwf0clhh0caqe20eujxgpeq
 
 AWS_ACCESS_KEY_ID=test
 AWS_DEFAULT_REGION=us-west-1

--- a/.local/db/seed.sql
+++ b/.local/db/seed.sql
@@ -1,6 +1,6 @@
 CREATE EXTENSION IF NOT EXISTS "pgcrypto";
 
--- Create the Dogfood Project
+-- Create the Console Project
 INSERT INTO projects (id, display_name, log_in_with_google, log_in_with_microsoft, log_in_with_email, log_in_with_password, log_in_with_saml, log_in_with_authenticator_app, log_in_with_passkey, vault_domain, email_send_from_domain, redirect_uri, cookie_domain)
 	VALUES ('56bfa2b3-4f5a-4c68-8fc5-db3bf20731a2'::uuid, 'Tesseral Local Development', true, true, true, true, true, true, true, 'vault.console.tesseral.example.com', 'vault.console.tesseral.example.com', 'https://console.tesseral.example.com', 'console.tesseral.example.com');
 
@@ -10,25 +10,25 @@ VALUES
     (gen_random_uuid(), '56bfa2b3-4f5a-4c68-8fc5-db3bf20731a2', 'vault.console.tesseral.example.com'),
     (gen_random_uuid(), '56bfa2b3-4f5a-4c68-8fc5-db3bf20731a2', 'console.tesseral.example.com');
 
--- Create the Dogfood Project's backing organization
+-- Create the Console Project's backing organization
 INSERT INTO organizations (id, display_name, project_id, log_in_with_google, log_in_with_microsoft, log_in_with_email, log_in_with_password, log_in_with_saml, log_in_with_authenticator_app, log_in_with_passkey, scim_enabled)
   VALUES ('7a76decb-6d79-49ce-9449-34fcc53151df'::uuid, 'project_54vwf0clhh0caqe20eujxgpeq Backing Organization', '56bfa2b3-4f5a-4c68-8fc5-db3bf20731a2', true, false, true, true, true, true, true, true);
 
 UPDATE projects SET organization_id = '7a76decb-6d79-49ce-9449-34fcc53151df'::uuid where id = '56bfa2b3-4f5a-4c68-8fc5-db3bf20731a2'::uuid;
 
--- Create a user in the dogfood project
+-- Create a user in the console project
 INSERT INTO users (id, email, password_bcrypt, organization_id, is_owner)
   VALUES (gen_random_uuid(), 'root@app.tesseral.example.com', crypt('password', gen_salt('bf', 14)), '7a76decb-6d79-49ce-9449-34fcc53151df', true);
 
--- Create project UI settings for the dogfood project
+-- Create project UI settings for the console project
 INSERT INTO project_ui_settings (id, project_id)
   VALUES (gen_random_uuid(), '56bfa2b3-4f5a-4c68-8fc5-db3bf20731a2'::uuid);
 
--- Create a backend API key in the dogfood project
+-- Create a backend API key in the console project
 INSERT INTO backend_api_keys (id, project_id, secret_token_sha256, display_name)
   VALUES (gen_random_uuid(), (SELECT id FROM projects LIMIT 1), digest(uuid_send('F938657E-65FC-4C43-B2F1-CE875A0B64D6'::uuid), 'sha256'), 'localhost');
 
--- Create a session signing key in the dogfood project
+-- Create a session signing key in the console project
 INSERT INTO session_signing_keys (id, project_id, public_key, private_key_cipher_text, expire_time) 
   VALUES (
     gen_random_uuid(), 

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -112,7 +112,7 @@ func main() {
 		SESSPFMXRecordValue                 string        `conf:"ses_spf_mx_record_value,noredact"`
 		DB                                  dbconn.Config `conf:"db,noredact"`
 		CloudflareAPIToken                  string        `conf:"cloudflare_api_token"`
-		DogfoodProjectID                    string        `conf:"dogfood_project_id,noredact"`
+		ConsoleProjectID                    string        `conf:"console_project_id,noredact"`
 		IntermediateSessionKMSKeyID         string        `conf:"intermediate_session_kms_key_id,noredact"`
 		KMSEndpoint                         string        `conf:"kms_endpoint_resolver_url,noredact"`
 		PageEncodingValue                   string        `conf:"page-encoding-value"`
@@ -207,11 +207,11 @@ func main() {
 		panic(fmt.Errorf("parse page encoding secret: %w", err))
 	}
 
-	dogfoodProjectID, err := idformat.Project.Parse(config.DogfoodProjectID)
+	consoleProjectID, err := idformat.Project.Parse(config.ConsoleProjectID)
 	if err != nil {
-		panic(fmt.Errorf("parse dogfood project ID: %w", err))
+		panic(fmt.Errorf("parse console project ID: %w", err))
 	}
-	uuidDogfoodProjectID := uuid.UUID(dogfoodProjectID[:])
+	uuidConsoleProjectID := uuid.UUID(consoleProjectID[:])
 
 	awsConfig, err := awsconfig.LoadDefaultConfig(context.Background())
 	if err != nil {
@@ -263,7 +263,7 @@ func main() {
 	// Register the backend service
 	backendStore := backendstore.New(backendstore.NewStoreParams{
 		DB:                                    db,
-		DogfoodProjectID:                      &uuidDogfoodProjectID,
+		ConsoleProjectID:                      &uuidConsoleProjectID,
 		ConsoleDomain:                         config.ConsoleDomain,
 		IntermediateSessionSigningKeyKMSKeyID: config.IntermediateSessionKMSKeyID,
 		KMS:                                   kms_,
@@ -296,7 +296,7 @@ func main() {
 		connect.WithInterceptors(
 			opaqueinternalerror.NewInterceptor(),
 			httplog.NewInterceptor(),
-			backendinterceptor.New(backendStore, config.DogfoodProjectID),
+			backendinterceptor.New(backendStore, config.ConsoleProjectID),
 		),
 	)
 	backend := vanguard.NewService(backendConnectPath, backendConnectHandler)
@@ -308,7 +308,7 @@ func main() {
 	// Register the frontend service
 	frontendStore := frontendstore.New(frontendstore.NewStoreParams{
 		DB:                                    db,
-		DogfoodProjectID:                      &uuidDogfoodProjectID,
+		ConsoleProjectID:                      &uuidConsoleProjectID,
 		ConsoleDomain:                         config.ConsoleDomain,
 		IntermediateSessionSigningKeyKMSKeyID: config.IntermediateSessionKMSKeyID,
 		OIDCClientSecretsKMSKeyID:             config.OIDCClientSecretsKMSKeyID,
@@ -344,7 +344,7 @@ func main() {
 		ConsoleDomain:                         config.ConsoleDomain,
 		AuthAppsRootDomain:                    config.AuthAppsRootDomain,
 		DB:                                    db,
-		DogfoodProjectID:                      &uuidDogfoodProjectID,
+		ConsoleProjectID:                      &uuidConsoleProjectID,
 		IntermediateSessionSigningKeyKMSKeyID: config.IntermediateSessionKMSKeyID,
 		KMS:                                   kms_,
 		PageEncoder:                           pagetoken.Encoder{Secret: pageEncodingValue},

--- a/cmd/openauthctl/bootstrap.go
+++ b/cmd/openauthctl/bootstrap.go
@@ -31,7 +31,7 @@ Bootstrap a Tesseral database.
 
 Outputs, tab-separated, a project ID, an email, and a very sensitive password.
 
-The project ID is the bootstrap ("dogfood") project ID. The email and password
+The project ID is the bootstrap ("console") project ID. The email and password
 are a login method for an admin user in that project.
 
 Delete this admin user before deploying this Tesseral instance in production.
@@ -67,18 +67,18 @@ func bootstrap(ctx context.Context, args bootstrapArgs) error {
 		SessionSigningKeyKmsKeyID: args.SessionSigningKMSKeyID,
 	})
 
-	res, err := s.CreateDogfoodProject(ctx, &store.CreateDogfoodProjectRequest{
+	res, err := s.CreateConsoleProject(ctx, &store.CreateConsoleProjectRequest{
 		RootUserEmail: args.RootUserEmail,
 		ConsoleDomain: args.ConsoleDomain,
 		VaultDomain:   args.VaultDomain,
 	})
 	if err != nil {
-		return fmt.Errorf("create dogfood project: %w", err)
+		return fmt.Errorf("create console project: %w", err)
 	}
 
 	fmt.Printf(
 		"%s\t%s\t%s\n",
-		res.DogfoodProjectID,
+		res.ConsoleProjectID,
 		res.BootstrapUserEmail,
 		res.BootstrapUserVerySensitivePassword,
 	)

--- a/console/build.mjs
+++ b/console/build.mjs
@@ -12,8 +12,8 @@ if (CONSOLE_BUILD_IS_DEV) {
 const context = await esbuild.context({
   bundle: true,
   define: {
-    __REPLACED_BY_ESBUILD_DOGFOOD_PROJECT_ID__: JSON.stringify(
-      process.env.CONSOLE_DOGFOOD_PROJECT_ID,
+    __REPLACED_BY_ESBUILD_CONSOLE_PROJECT_ID__: JSON.stringify(
+      process.env.CONSOLE_CONSOLE_PROJECT_ID,
     ),
     __REPLACED_BY_ESBUILD_API_URL__: JSON.stringify(
       process.env.CONSOLE_API_URL,

--- a/console/src/config.ts
+++ b/console/src/config.ts
@@ -1,4 +1,4 @@
 // @ts-expect-error esbuild replaces this at build time, but tsc-check doesn't know that
 export const API_URL = __REPLACED_BY_ESBUILD_API_URL__;
 // @ts-expect-error ibid
-export const DOGFOOD_PROJECT_ID = __REPLACED_BY_ESBUILD_DOGFOOD_PROJECT_ID__;
+export const CONSOLE_PROJECT_ID = __REPLACED_BY_ESBUILD_CONSOLE_PROJECT_ID__;

--- a/console/src/lib/AccessTokenProvider.tsx
+++ b/console/src/lib/AccessTokenProvider.tsx
@@ -1,6 +1,6 @@
 import React, { createContext, useEffect, useMemo, useState } from "react";
 
-import { API_URL, DOGFOOD_PROJECT_ID } from "@/config";
+import { API_URL, CONSOLE_PROJECT_ID } from "@/config";
 
 import { parseAccessToken } from "./parse-access-token";
 
@@ -22,7 +22,7 @@ export function useAccessToken() {
 function useAccessTokenInternal(): string | undefined {
   const [error, setError] = useState<unknown>();
   const [accessToken, setAccessToken] = useState(() => {
-    return getCookie(`tesseral_${DOGFOOD_PROJECT_ID}_access_token`);
+    return getCookie(`tesseral_${CONSOLE_PROJECT_ID}_access_token`);
   });
   const accessTokenLikelyValid = useAccessTokenLikelyValid(accessToken ?? "");
 

--- a/console/src/lib/access-token-provider.tsx
+++ b/console/src/lib/access-token-provider.tsx
@@ -3,7 +3,7 @@ import { useMutation } from "@connectrpc/connect-query";
 import React, { createContext, useEffect, useMemo, useState } from "react";
 import { useNavigate } from "react-router";
 
-import { DOGFOOD_PROJECT_ID } from "@/config";
+import { CONSOLE_PROJECT_ID } from "@/config";
 import { refresh } from "@/gen/tesseral/frontend/v1/frontend-FrontendService_connectquery";
 
 import { parseAccessToken } from "./parse-access-token";
@@ -27,7 +27,7 @@ function useAccessTokenInternal(): string | undefined {
   const navigate = useNavigate();
   const [error, setError] = useState<unknown>();
   const [accessToken, setAccessToken] = useState(() => {
-    return getCookie(`tesseral_${DOGFOOD_PROJECT_ID}_access_token`);
+    return getCookie(`tesseral_${CONSOLE_PROJECT_ID}_access_token`);
   });
   const { mutateAsync: refreshAsync } = useMutation(refresh);
   const { accessTokenLikelyValid } = useAccessTokenLikelyValid(

--- a/internal/backend/authn/authn.go
+++ b/internal/backend/authn/authn.go
@@ -10,7 +10,7 @@ import (
 
 type ContextData struct {
 	ProjectAPIKey  *BackendAPIKeyContextData
-	DogfoodSession *DogfoodSessionContextData
+	ConsoleSession *ConsoleSessionContextData
 }
 
 type BackendAPIKeyContextData struct {
@@ -18,14 +18,14 @@ type BackendAPIKeyContextData struct {
 	ProjectID       string
 }
 
-// DogfoodSessionContextData contains data related to a user logged into
+// ConsoleSessionContextData contains data related to a user logged into
 // app.tesseral.com.
-type DogfoodSessionContextData struct {
+type ConsoleSessionContextData struct {
 	UserID    string
 	SessionID string
 
 	// ProjectID is the ID of the project the user is manipulating. This is
-	// almost never the same thing as the dogfood project.
+	// almost never the same thing as the console project.
 	ProjectID string
 }
 
@@ -35,8 +35,8 @@ func NewBackendAPIKeyContext(ctx context.Context, projectAPIKey *BackendAPIKeyCo
 	return context.WithValue(ctx, ctxKey{}, ContextData{ProjectAPIKey: projectAPIKey})
 }
 
-func NewDogfoodSessionContext(ctx context.Context, dogfoodSession DogfoodSessionContextData) context.Context {
-	return context.WithValue(ctx, ctxKey{}, ContextData{DogfoodSession: &dogfoodSession})
+func NewConsoleSessionContext(ctx context.Context, consoleSession ConsoleSessionContextData) context.Context {
+	return context.WithValue(ctx, ctxKey{}, ContextData{ConsoleSession: &consoleSession})
 }
 
 func GetContextData(ctx context.Context) ContextData {
@@ -57,8 +57,8 @@ func ProjectID(ctx context.Context) uuid.UUID {
 	switch {
 	case v.ProjectAPIKey != nil:
 		projectID = v.ProjectAPIKey.ProjectID
-	case v.DogfoodSession != nil:
-		projectID = v.DogfoodSession.ProjectID
+	case v.ConsoleSession != nil:
+		projectID = v.ConsoleSession.ProjectID
 	default:
 		panic("unsupported authn ctx data")
 	}

--- a/internal/backend/store/backend_api_keys.go
+++ b/internal/backend/store/backend_api_keys.go
@@ -17,8 +17,8 @@ import (
 )
 
 func (s *Store) ListBackendAPIKeys(ctx context.Context, req *backendv1.ListBackendAPIKeysRequest) (*backendv1.ListBackendAPIKeysResponse, error) {
-	if err := validateIsDogfoodSession(ctx); err != nil {
-		return nil, fmt.Errorf("validate is dogfood session: %w", err)
+	if err := validateIsConsoleSession(ctx); err != nil {
+		return nil, fmt.Errorf("validate is console session: %w", err)
 	}
 
 	_, q, _, rollback, err := s.tx(ctx)
@@ -60,8 +60,8 @@ func (s *Store) ListBackendAPIKeys(ctx context.Context, req *backendv1.ListBacke
 }
 
 func (s *Store) GetBackendAPIKey(ctx context.Context, req *backendv1.GetBackendAPIKeyRequest) (*backendv1.GetBackendAPIKeyResponse, error) {
-	if err := validateIsDogfoodSession(ctx); err != nil {
-		return nil, fmt.Errorf("validate is dogfood session: %w", err)
+	if err := validateIsConsoleSession(ctx); err != nil {
+		return nil, fmt.Errorf("validate is console session: %w", err)
 	}
 
 	id, err := idformat.BackendAPIKey.Parse(req.Id)
@@ -85,8 +85,8 @@ func (s *Store) GetBackendAPIKey(ctx context.Context, req *backendv1.GetBackendA
 }
 
 func (s *Store) CreateBackendAPIKey(ctx context.Context, req *backendv1.CreateBackendAPIKeyRequest) (*backendv1.CreateBackendAPIKeyResponse, error) {
-	if err := validateIsDogfoodSession(ctx); err != nil {
-		return nil, fmt.Errorf("validate is dogfood session: %w", err)
+	if err := validateIsConsoleSession(ctx); err != nil {
+		return nil, fmt.Errorf("validate is console session: %w", err)
 	}
 
 	qProject, err := s.q.GetProjectByID(ctx, authn.ProjectID(ctx))
@@ -126,8 +126,8 @@ func (s *Store) CreateBackendAPIKey(ctx context.Context, req *backendv1.CreateBa
 }
 
 func (s *Store) UpdateBackendAPIKey(ctx context.Context, req *backendv1.UpdateBackendAPIKeyRequest) (*backendv1.UpdateBackendAPIKeyResponse, error) {
-	if err := validateIsDogfoodSession(ctx); err != nil {
-		return nil, fmt.Errorf("validate is dogfood session: %w", err)
+	if err := validateIsConsoleSession(ctx); err != nil {
+		return nil, fmt.Errorf("validate is console session: %w", err)
 	}
 
 	_, q, commit, rollback, err := s.tx(ctx)
@@ -175,8 +175,8 @@ func (s *Store) UpdateBackendAPIKey(ctx context.Context, req *backendv1.UpdateBa
 }
 
 func (s *Store) DeleteBackendAPIKey(ctx context.Context, req *backendv1.DeleteBackendAPIKeyRequest) (*backendv1.DeleteBackendAPIKeyResponse, error) {
-	if err := validateIsDogfoodSession(ctx); err != nil {
-		return nil, fmt.Errorf("validate is dogfood session: %w", err)
+	if err := validateIsConsoleSession(ctx); err != nil {
+		return nil, fmt.Errorf("validate is console session: %w", err)
 	}
 
 	_, q, commit, rollback, err := s.tx(ctx)
@@ -218,8 +218,8 @@ func (s *Store) DeleteBackendAPIKey(ctx context.Context, req *backendv1.DeleteBa
 }
 
 func (s *Store) RevokeBackendAPIKey(ctx context.Context, req *backendv1.RevokeBackendAPIKeyRequest) (*backendv1.RevokeBackendAPIKeyResponse, error) {
-	if err := validateIsDogfoodSession(ctx); err != nil {
-		return nil, fmt.Errorf("validate is dogfood session: %w", err)
+	if err := validateIsConsoleSession(ctx); err != nil {
+		return nil, fmt.Errorf("validate is console session: %w", err)
 	}
 
 	_, q, commit, rollback, err := s.tx(ctx)

--- a/internal/backend/store/impersonate.go
+++ b/internal/backend/store/impersonate.go
@@ -18,11 +18,11 @@ import (
 const userImpersonationTokenDuration = time.Second * 30
 
 func (s *Store) CreateUserImpersonationToken(ctx context.Context, req *backendv1.CreateUserImpersonationTokenRequest) (*backendv1.CreateUserImpersonationTokenResponse, error) {
-	if err := validateIsDogfoodSession(ctx); err != nil {
-		return nil, fmt.Errorf("validate is dogfood session: %w", err)
+	if err := validateIsConsoleSession(ctx); err != nil {
+		return nil, fmt.Errorf("validate is console session: %w", err)
 	}
 
-	impersonatorID, err := idformat.User.Parse(authn.GetContextData(ctx).DogfoodSession.UserID)
+	impersonatorID, err := idformat.User.Parse(authn.GetContextData(ctx).ConsoleSession.UserID)
 	if err != nil {
 		panic(fmt.Errorf("parse user id: %w", err))
 	}
@@ -34,7 +34,7 @@ func (s *Store) CreateUserImpersonationToken(ctx context.Context, req *backendv1
 	defer rollback()
 
 	qImpersonator, err := q.GetUser(ctx, queries.GetUserParams{
-		ProjectID: *s.dogfoodProjectID,
+		ProjectID: *s.consoleProjectID,
 		ID:        impersonatorID,
 	})
 	if err != nil {

--- a/internal/backend/store/impersonate_test.go
+++ b/internal/backend/store/impersonate_test.go
@@ -31,6 +31,6 @@ func TestCreateUserImpersonationToken(t *testing.T) {
 	require.True(t, res.UserImpersonationToken.CreateTime.AsTime().Before(time.Now()))
 	require.True(t, res.UserImpersonationToken.ExpireTime.AsTime().After(time.Now()))
 	require.Equal(t, userID, res.UserImpersonationToken.ImpersonatedId)
-	require.NotEmpty(t, authn.GetContextData(ctx).DogfoodSession.UserID, res.UserImpersonationToken.ImpersonatorId)
+	require.NotEmpty(t, authn.GetContextData(ctx).ConsoleSession.UserID, res.UserImpersonationToken.ImpersonatorId)
 	require.NotEmpty(t, res.UserImpersonationToken.SecretToken)
 }

--- a/internal/backend/store/log_audit_event.go
+++ b/internal/backend/store/log_audit_event.go
@@ -52,18 +52,18 @@ func (s *Store) logAuditEvent(ctx context.Context, q *queries.Queries, data logA
 			return queries.AuditLogEvent{}, fmt.Errorf("parse backend api key id: %w", err)
 		}
 		qEventParams.ActorBackendApiKeyID = (*uuid.UUID)(&backendApiKeyUUID)
-	case contextData.DogfoodSession != nil:
-		dogfoodUserUUID, err := idformat.User.Parse(contextData.DogfoodSession.UserID)
+	case contextData.ConsoleSession != nil:
+		consoleUserUUID, err := idformat.User.Parse(contextData.ConsoleSession.UserID)
 		if err != nil {
-			return queries.AuditLogEvent{}, fmt.Errorf("parse dogfood session user id: %w", err)
+			return queries.AuditLogEvent{}, fmt.Errorf("parse console session user id: %w", err)
 		}
-		qEventParams.ActorConsoleUserID = (*uuid.UUID)(&dogfoodUserUUID)
+		qEventParams.ActorConsoleUserID = (*uuid.UUID)(&consoleUserUUID)
 
-		dogfoodSessionUUID, err := idformat.Session.Parse(contextData.DogfoodSession.SessionID)
+		consoleSessionUUID, err := idformat.Session.Parse(contextData.ConsoleSession.SessionID)
 		if err != nil {
-			return queries.AuditLogEvent{}, fmt.Errorf("parse dogfood session project id: %w", err)
+			return queries.AuditLogEvent{}, fmt.Errorf("parse console session project id: %w", err)
 		}
-		qEventParams.ActorConsoleSessionID = (*uuid.UUID)(&dogfoodSessionUUID)
+		qEventParams.ActorConsoleSessionID = (*uuid.UUID)(&consoleSessionUUID)
 	}
 
 	qEvent, err := q.CreateAuditLogEvent(ctx, qEventParams)

--- a/internal/backend/store/organizations.go
+++ b/internal/backend/store/organizations.go
@@ -25,12 +25,12 @@ func (s *Store) CreateOrganization(ctx context.Context, req *backendv1.CreateOrg
 	}
 	defer rollback()
 
-	// Creating organizations directly on the Dogfood Project
+	// Creating organizations directly on the Console Project
 	// without a project to back with the organization will
 	// break the intermediate service, so we restrict the
 	// ability to create an organization in this case.
-	if authn.ProjectID(ctx) == *s.dogfoodProjectID {
-		return nil, apierror.NewPermissionDeniedError("dogfood project cannot create organizations", fmt.Errorf("dogfood project cannot create organizations"))
+	if authn.ProjectID(ctx) == *s.consoleProjectID {
+		return nil, apierror.NewPermissionDeniedError("console project cannot create organizations", fmt.Errorf("console project cannot create organizations"))
 	}
 
 	qProject, err := q.GetProjectByID(ctx, authn.ProjectID(ctx))
@@ -460,8 +460,8 @@ func (s *Store) DeleteOrganization(ctx context.Context, req *backendv1.DeleteOrg
 }
 
 func (s *Store) DisableOrganizationLogins(ctx context.Context, req *backendv1.DisableOrganizationLoginsRequest) (*backendv1.DisableOrganizationLoginsResponse, error) {
-	if err := validateIsDogfoodSession(ctx); err != nil {
-		return nil, fmt.Errorf("validate is dogfood session: %w", err)
+	if err := validateIsConsoleSession(ctx); err != nil {
+		return nil, fmt.Errorf("validate is console session: %w", err)
 	}
 
 	_, q, commit, rollback, err := s.tx(ctx)
@@ -486,8 +486,8 @@ func (s *Store) DisableOrganizationLogins(ctx context.Context, req *backendv1.Di
 }
 
 func (s *Store) EnableOrganizationLogins(ctx context.Context, req *backendv1.EnableOrganizationLoginsRequest) (*backendv1.EnableOrganizationLoginsResponse, error) {
-	if err := validateIsDogfoodSession(ctx); err != nil {
-		return nil, fmt.Errorf("validate is dogfood session: %w", err)
+	if err := validateIsConsoleSession(ctx); err != nil {
+		return nil, fmt.Errorf("validate is console session: %w", err)
 	}
 
 	_, q, commit, rollback, err := s.tx(ctx)

--- a/internal/backend/store/project_onboarding_progress.go
+++ b/internal/backend/store/project_onboarding_progress.go
@@ -13,8 +13,8 @@ import (
 )
 
 func (s *Store) GetProjectOnboardingProgress(ctx context.Context, req *backendv1.GetProjectOnboardingProgressRequest) (*backendv1.GetProjectOnboardingProgressResponse, error) {
-	if err := validateIsDogfoodSession(ctx); err != nil {
-		return nil, fmt.Errorf("validate is dogfood session: %w", err)
+	if err := validateIsConsoleSession(ctx); err != nil {
+		return nil, fmt.Errorf("validate is console session: %w", err)
 	}
 
 	_, q, _, rollback, err := s.tx(ctx)
@@ -41,8 +41,8 @@ func (s *Store) GetProjectOnboardingProgress(ctx context.Context, req *backendv1
 }
 
 func (s *Store) UpdateProjectOnboardingProgress(ctx context.Context, req *backendv1.UpdateProjectOnboardingProgressRequest) (*backendv1.UpdateProjectOnboardingProgressResponse, error) {
-	if err := validateIsDogfoodSession(ctx); err != nil {
-		return nil, fmt.Errorf("validate is dogfood session: %w", err)
+	if err := validateIsConsoleSession(ctx); err != nil {
+		return nil, fmt.Errorf("validate is console session: %w", err)
 	}
 
 	_, q, commit, rollback, err := s.tx(ctx)

--- a/internal/backend/store/publishable_keys.go
+++ b/internal/backend/store/publishable_keys.go
@@ -16,8 +16,8 @@ import (
 )
 
 func (s *Store) ListPublishableKeys(ctx context.Context, req *backendv1.ListPublishableKeysRequest) (*backendv1.ListPublishableKeysResponse, error) {
-	if err := validateIsDogfoodSession(ctx); err != nil {
-		return nil, fmt.Errorf("validate is dogfood session: %w", err)
+	if err := validateIsConsoleSession(ctx); err != nil {
+		return nil, fmt.Errorf("validate is console session: %w", err)
 	}
 
 	_, q, _, rollback, err := s.tx(ctx)
@@ -59,8 +59,8 @@ func (s *Store) ListPublishableKeys(ctx context.Context, req *backendv1.ListPubl
 }
 
 func (s *Store) GetPublishableKey(ctx context.Context, req *backendv1.GetPublishableKeyRequest) (*backendv1.GetPublishableKeyResponse, error) {
-	if err := validateIsDogfoodSession(ctx); err != nil {
-		return nil, fmt.Errorf("validate is dogfood session: %w", err)
+	if err := validateIsConsoleSession(ctx); err != nil {
+		return nil, fmt.Errorf("validate is console session: %w", err)
 	}
 
 	id, err := idformat.PublishableKey.Parse(req.Id)
@@ -84,8 +84,8 @@ func (s *Store) GetPublishableKey(ctx context.Context, req *backendv1.GetPublish
 }
 
 func (s *Store) CreatePublishableKey(ctx context.Context, req *backendv1.CreatePublishableKeyRequest) (*backendv1.CreatePublishableKeyResponse, error) {
-	if err := validateIsDogfoodSession(ctx); err != nil {
-		return nil, fmt.Errorf("validate is dogfood session: %w", err)
+	if err := validateIsConsoleSession(ctx); err != nil {
+		return nil, fmt.Errorf("validate is console session: %w", err)
 	}
 
 	_, q, commit, rollback, err := s.tx(ctx)
@@ -112,8 +112,8 @@ func (s *Store) CreatePublishableKey(ctx context.Context, req *backendv1.CreateP
 }
 
 func (s *Store) UpdatePublishableKey(ctx context.Context, req *backendv1.UpdatePublishableKeyRequest) (*backendv1.UpdatePublishableKeyResponse, error) {
-	if err := validateIsDogfoodSession(ctx); err != nil {
-		return nil, fmt.Errorf("validate is dogfood session: %w", err)
+	if err := validateIsConsoleSession(ctx); err != nil {
+		return nil, fmt.Errorf("validate is console session: %w", err)
 	}
 
 	_, q, commit, rollback, err := s.tx(ctx)
@@ -165,8 +165,8 @@ func (s *Store) UpdatePublishableKey(ctx context.Context, req *backendv1.UpdateP
 }
 
 func (s *Store) DeletePublishableKey(ctx context.Context, req *backendv1.DeletePublishableKeyRequest) (*backendv1.DeletePublishableKeyResponse, error) {
-	if err := validateIsDogfoodSession(ctx); err != nil {
-		return nil, fmt.Errorf("validate is dogfood session: %w", err)
+	if err := validateIsConsoleSession(ctx); err != nil {
+		return nil, fmt.Errorf("validate is console session: %w", err)
 	}
 
 	_, q, commit, rollback, err := s.tx(ctx)

--- a/internal/backend/store/store.go
+++ b/internal/backend/store/store.go
@@ -26,7 +26,7 @@ import (
 
 type Store struct {
 	db                                    *pgxpool.Pool
-	dogfoodProjectID                      *uuid.UUID
+	consoleProjectID                      *uuid.UUID
 	consoleDomain                         string
 	intermediateSessionSigningKeyKMSKeyID string
 	kms                                   *kms.Client
@@ -57,7 +57,7 @@ type Store struct {
 
 type NewStoreParams struct {
 	DB                                    *pgxpool.Pool
-	DogfoodProjectID                      *uuid.UUID
+	ConsoleProjectID                      *uuid.UUID
 	ConsoleDomain                         string
 	IntermediateSessionSigningKeyKMSKeyID string
 	KMS                                   *kms.Client
@@ -87,7 +87,7 @@ type NewStoreParams struct {
 func New(p NewStoreParams) *Store {
 	store := &Store{
 		db:                                    p.DB,
-		dogfoodProjectID:                      p.DogfoodProjectID,
+		consoleProjectID:                      p.ConsoleProjectID,
 		consoleDomain:                         p.ConsoleDomain,
 		intermediateSessionSigningKeyKMSKeyID: p.IntermediateSessionSigningKeyKMSKeyID,
 		kms:                                   p.KMS,
@@ -153,15 +153,15 @@ func timestampOrNil(t *time.Time) *timestamppb.Timestamp {
 	return timestamppb.New(*t)
 }
 
-// validateIsDogfoodSession returns an error if the caller isn't a dogfood
+// validateIsConsoleSession returns an error if the caller isn't a console
 // session.
 //
 // The intention of this method is to allow endpoints to prevent themselves from
 // being called by project API keys.
-func validateIsDogfoodSession(ctx context.Context) error {
+func validateIsConsoleSession(ctx context.Context) error {
 	data := authn.GetContextData(ctx)
-	if data.DogfoodSession == nil {
-		return apierror.NewUnauthenticatedError("this endpoint cannot be invoked by project API keys", fmt.Errorf("non-dogfood session request"))
+	if data.ConsoleSession == nil {
+		return apierror.NewUnauthenticatedError("this endpoint cannot be invoked by project API keys", fmt.Errorf("non-console session request"))
 	}
 	return nil
 }

--- a/internal/backend/store/store_test.go
+++ b/internal/backend/store/store_test.go
@@ -43,7 +43,7 @@ func newTestUtil(t *testing.T) (context.Context, *testUtil) {
 		MicrosoftOAuthClientSecretsKMSKeyID: environment.KMS.MicrosoftOAuthClientSecretsKMSKeyID,
 		GithubOAuthClientSecretsKMSKeyID:    environment.KMS.GithubOAuthClientSecretsKMSKeyID,
 		OIDCClientSecretsKMSKeyID:           environment.KMS.OIDCClientSecretsKMSKeyID,
-		DogfoodProjectID:                    environment.DogfoodProjectID,
+		ConsoleProjectID:                    environment.ConsoleProjectID,
 		ConsoleDomain:                       environment.ConsoleDomain,
 		AuthAppsRootDomain:                  environment.AuthAppsRootDomain,
 		OIDCClient:                          &oidcclient.Client{HTTPClient: http.DefaultClient},
@@ -56,7 +56,7 @@ func newTestUtil(t *testing.T) (context.Context, *testUtil) {
 	})
 
 	projectID, projectUserID := environment.NewProject(t)
-	ctx := authn.NewDogfoodSessionContext(t.Context(), authn.DogfoodSessionContextData{
+	ctx := authn.NewConsoleSessionContext(t.Context(), authn.ConsoleSessionContextData{
 		ProjectID: projectID,
 		UserID:    projectUserID,
 		SessionID: idformat.Session.Format(uuid.New()),

--- a/internal/backend/store/stripe.go
+++ b/internal/backend/store/stripe.go
@@ -23,8 +23,8 @@ func (s *Store) GetProjectEntitlements(ctx context.Context, req *backendv1.GetPr
 }
 
 func (s *Store) CreateStripeCheckoutLink(ctx context.Context, req *backendv1.CreateStripeCheckoutLinkRequest) (*backendv1.CreateStripeCheckoutLinkResponse, error) {
-	if err := validateIsDogfoodSession(ctx); err != nil {
-		return nil, fmt.Errorf("validate is dogfood session: %w", err)
+	if err := validateIsConsoleSession(ctx); err != nil {
+		return nil, fmt.Errorf("validate is console session: %w", err)
 	}
 
 	qProject, err := s.q.GetProjectByID(ctx, authn.ProjectID(ctx))

--- a/internal/backend/store/user_invites.go
+++ b/internal/backend/store/user_invites.go
@@ -280,7 +280,7 @@ func (s *Store) sendUserInviteEmail(ctx context.Context, toAddress string, organ
 	subject := fmt.Sprintf("%s - You've been invited to join %s", qProject.DisplayName, organizationDisplayName)
 
 	vaultDomain := qProject.VaultDomain
-	if authn.ProjectID(ctx) == *s.dogfoodProjectID {
+	if authn.ProjectID(ctx) == *s.consoleProjectID {
 		vaultDomain = s.consoleDomain
 	}
 

--- a/internal/backend/store/vault_domain_settings.go
+++ b/internal/backend/store/vault_domain_settings.go
@@ -20,8 +20,8 @@ import (
 )
 
 func (s *Store) GetVaultDomainSettings(ctx context.Context, req *backendv1.GetVaultDomainSettingsRequest) (*backendv1.GetVaultDomainSettingsResponse, error) {
-	if err := validateIsDogfoodSession(ctx); err != nil {
-		return nil, fmt.Errorf("validate is dogfood session: %w", err)
+	if err := validateIsConsoleSession(ctx); err != nil {
+		return nil, fmt.Errorf("validate is console session: %w", err)
 	}
 
 	vaultDomainSettings, err := s.getVaultDomainSettings(ctx)
@@ -35,8 +35,8 @@ func (s *Store) GetVaultDomainSettings(ctx context.Context, req *backendv1.GetVa
 }
 
 func (s *Store) UpdateVaultDomainSettings(ctx context.Context, req *backendv1.UpdateVaultDomainSettingsRequest) (*backendv1.UpdateVaultDomainSettingsResponse, error) {
-	if err := validateIsDogfoodSession(ctx); err != nil {
-		return nil, fmt.Errorf("validate is dogfood session: %w", err)
+	if err := validateIsConsoleSession(ctx); err != nil {
+		return nil, fmt.Errorf("validate is console session: %w", err)
 	}
 
 	qProject, err := s.q.GetProjectByID(ctx, authn.ProjectID(ctx))
@@ -113,8 +113,8 @@ func (s *Store) UpdateVaultDomainSettings(ctx context.Context, req *backendv1.Up
 }
 
 func (s *Store) EnableCustomVaultDomain(ctx context.Context, req *backendv1.EnableCustomVaultDomainRequest) (*backendv1.EnableCustomVaultDomainResponse, error) {
-	if err := validateIsDogfoodSession(ctx); err != nil {
-		return nil, fmt.Errorf("validate is dogfood session: %w", err)
+	if err := validateIsConsoleSession(ctx); err != nil {
+		return nil, fmt.Errorf("validate is console session: %w", err)
 	}
 
 	vaultDomainSettings, err := s.getVaultDomainSettings(ctx)
@@ -162,8 +162,8 @@ func (s *Store) EnableCustomVaultDomain(ctx context.Context, req *backendv1.Enab
 }
 
 func (s *Store) EnableEmailSendFromDomain(ctx context.Context, req *backendv1.EnableEmailSendFromDomainRequest) (*backendv1.EnableEmailSendFromDomainResponse, error) {
-	if err := validateIsDogfoodSession(ctx); err != nil {
-		return nil, fmt.Errorf("validate is dogfood session: %w", err)
+	if err := validateIsConsoleSession(ctx); err != nil {
+		return nil, fmt.Errorf("validate is console session: %w", err)
 	}
 
 	vaultDomainSettings, err := s.getVaultDomainSettings(ctx)

--- a/internal/frontend/store/store.go
+++ b/internal/frontend/store/store.go
@@ -22,7 +22,7 @@ import (
 
 type Store struct {
 	db                                    *pgxpool.Pool
-	dogfoodProjectID                      *uuid.UUID
+	consoleProjectID                      *uuid.UUID
 	consoleDomain                         string
 	hibp                                  *hibp.Client
 	intermediateSessionSigningKeyKMSKeyID string
@@ -40,7 +40,7 @@ type Store struct {
 
 type NewStoreParams struct {
 	DB                                    *pgxpool.Pool
-	DogfoodProjectID                      *uuid.UUID
+	ConsoleProjectID                      *uuid.UUID
 	ConsoleDomain                         string
 	IntermediateSessionSigningKeyKMSKeyID string
 	OIDCClientSecretsKMSKeyID             string
@@ -57,7 +57,7 @@ type NewStoreParams struct {
 func New(p NewStoreParams) *Store {
 	store := &Store{
 		db:               p.DB,
-		dogfoodProjectID: p.DogfoodProjectID,
+		consoleProjectID: p.ConsoleProjectID,
 		consoleDomain:    p.ConsoleDomain,
 		hibp: &hibp.Client{
 			HTTPClient: http.DefaultClient,

--- a/internal/frontend/store/store_test.go
+++ b/internal/frontend/store/store_test.go
@@ -38,7 +38,7 @@ func newTestUtil(t *testing.T) *testUtil {
 		DB:                              environment.DB,
 		KMS:                             environment.KMS.Client,
 		SessionSigningKeyKmsKeyID:       environment.KMS.SessionSigningKeyID,
-		DogfoodProjectID:                environment.DogfoodProjectID,
+		ConsoleProjectID:                environment.ConsoleProjectID,
 		ConsoleDomain:                   environment.ConsoleDomain,
 		AuthenticatorAppSecretsKMSKeyID: environment.KMS.AuthenticatorAppSecretsKMSKeyID,
 		OIDCClientSecretsKMSKeyID:       environment.KMS.OIDCClientSecretsKMSKeyID,

--- a/internal/frontend/store/switch_orgs.go
+++ b/internal/frontend/store/switch_orgs.go
@@ -33,8 +33,8 @@ func (s *Store) ListSwitchableOrganizations(ctx context.Context, req *frontendv1
 	var orgs []*frontendv1.SwitchableOrganization
 	for _, qOrg := range qOrgs {
 		displayName := qOrg.DisplayName
-		if authn.ProjectID(ctx) == *s.dogfoodProjectID {
-			// for the dogfood project, use the display name of the project this
+		if authn.ProjectID(ctx) == *s.consoleProjectID {
+			// for the console project, use the display name of the project this
 			// org backs
 			qProject, err := q.GetProjectByBackingOrganizationID(ctx, &qOrg.ID)
 			if err != nil {

--- a/internal/frontend/store/user_invites.go
+++ b/internal/frontend/store/user_invites.go
@@ -277,7 +277,7 @@ func (s *Store) sendUserInviteEmail(ctx context.Context, toAddress string, organ
 	subject := fmt.Sprintf("%s - You've been invited to join %s", qProject.DisplayName, organizationDisplayName)
 
 	vaultDomain := qProject.VaultDomain
-	if authn.ProjectID(ctx) == *s.dogfoodProjectID {
+	if authn.ProjectID(ctx) == *s.consoleProjectID {
 		vaultDomain = s.consoleDomain
 	}
 

--- a/internal/intermediate/store/email_verification_challenges.go
+++ b/internal/intermediate/store/email_verification_challenges.go
@@ -188,7 +188,7 @@ func (s *Store) sendEmailVerificationChallenge(ctx context.Context, toAddress st
 	subject := fmt.Sprintf("%s - Verify your email address", qProject.DisplayName)
 
 	vaultDomain := qProject.VaultDomain
-	if authn.ProjectID(ctx) == *s.dogfoodProjectID {
+	if authn.ProjectID(ctx) == *s.consoleProjectID {
 		vaultDomain = s.consoleDomain
 	}
 

--- a/internal/intermediate/store/organizations.go
+++ b/internal/intermediate/store/organizations.go
@@ -18,8 +18,8 @@ import (
 )
 
 func (s *Store) CreateOrganization(ctx context.Context, req *intermediatev1.CreateOrganizationRequest) (*intermediatev1.CreateOrganizationResponse, error) {
-	if authn.ProjectID(ctx) == *s.dogfoodProjectID {
-		return nil, apierror.NewFailedPreconditionError("cannot create organization in this project", fmt.Errorf("dogfood project does not support directo organization creation"))
+	if authn.ProjectID(ctx) == *s.consoleProjectID {
+		return nil, apierror.NewFailedPreconditionError("cannot create organization in this project", fmt.Errorf("console project does not support directo organization creation"))
 	}
 
 	intermediateSession := authn.IntermediateSession(ctx)
@@ -195,9 +195,9 @@ func (s *Store) ListOrganizations(ctx context.Context, req *intermediatev1.ListO
 			org.UserHasPasskey = hasPasskeys
 		}
 
-		// if we're servicing the dogfood project, then show the display name of
+		// if we're servicing the console project, then show the display name of
 		// the project this organization backs
-		if authn.ProjectID(ctx) == *s.dogfoodProjectID {
+		if authn.ProjectID(ctx) == *s.consoleProjectID {
 			qBackedProject, err := q.GetProjectByBackingOrganizationID(ctx, &qOrg.ID)
 			if err != nil {
 				return nil, fmt.Errorf("get project by backing organization id: %w", err)

--- a/internal/intermediate/store/store.go
+++ b/internal/intermediate/store/store.go
@@ -26,7 +26,7 @@ type Store struct {
 	consoleDomain                         string
 	authAppsRootDomain                    string
 	db                                    *pgxpool.Pool
-	dogfoodProjectID                      *uuid.UUID
+	consoleProjectID                      *uuid.UUID
 	hibp                                  *hibp.Client
 	intermediateSessionSigningKeyKMSKeyID string
 	s3                                    *s3.Client
@@ -63,7 +63,7 @@ type NewStoreParams struct {
 	ConsoleDomain                         string
 	AuthAppsRootDomain                    string
 	DB                                    *pgxpool.Pool
-	DogfoodProjectID                      *uuid.UUID
+	ConsoleProjectID                      *uuid.UUID
 	IntermediateSessionSigningKeyKMSKeyID string
 	S3                                    *s3.Client
 	KMS                                   *kms.Client
@@ -98,7 +98,7 @@ func New(p NewStoreParams) *Store {
 		consoleDomain:      p.ConsoleDomain,
 		authAppsRootDomain: p.AuthAppsRootDomain,
 		db:                 p.DB,
-		dogfoodProjectID:   p.DogfoodProjectID,
+		consoleProjectID:   p.ConsoleProjectID,
 		hibp: &hibp.Client{
 			HTTPClient: http.DefaultClient,
 		},

--- a/internal/intermediate/store/store_test.go
+++ b/internal/intermediate/store/store_test.go
@@ -37,7 +37,7 @@ func newTestUtil(t *testing.T) (context.Context, *testUtil) {
 		S3:                        environment.S3.Client,
 		KMS:                       environment.KMS.Client,
 		SessionSigningKeyKmsKeyID: environment.KMS.SessionSigningKeyID,
-		DogfoodProjectID:          environment.DogfoodProjectID,
+		ConsoleProjectID:          environment.ConsoleProjectID,
 		ConsoleDomain:             environment.ConsoleDomain,
 	})
 	projectID, _ := environment.NewProject(t)

--- a/internal/store/queries/queries.sql.go
+++ b/internal/store/queries/queries.sql.go
@@ -26,14 +26,14 @@ func (q *Queries) CountAllProjects(ctx context.Context) (int64, error) {
 	return count, err
 }
 
-const createDogfoodProject = `-- name: CreateDogfoodProject :one
+const createConsoleProject = `-- name: CreateConsoleProject :one
 INSERT INTO projects (id, display_name, redirect_uri, log_in_with_google, log_in_with_microsoft, log_in_with_email, log_in_with_password, vault_domain, email_send_from_domain, cookie_domain)
     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
 RETURNING
     id, organization_id, log_in_with_password, log_in_with_google, log_in_with_microsoft, google_oauth_client_id, microsoft_oauth_client_id, google_oauth_client_secret_ciphertext, microsoft_oauth_client_secret_ciphertext, display_name, create_time, update_time, logins_disabled, log_in_with_authenticator_app, log_in_with_passkey, log_in_with_email, log_in_with_saml, redirect_uri, after_login_redirect_uri, after_signup_redirect_uri, vault_domain, email_send_from_domain, cookie_domain, email_quota_daily, stripe_customer_id, entitled_custom_vault_domains, entitled_backend_api_keys, log_in_with_github, github_oauth_client_id, github_oauth_client_secret_ciphertext, api_keys_enabled, api_key_secret_token_prefix, audit_logs_enabled, log_in_with_oidc
 `
 
-type CreateDogfoodProjectParams struct {
+type CreateConsoleProjectParams struct {
 	ID                  uuid.UUID
 	DisplayName         string
 	RedirectUri         string
@@ -46,8 +46,8 @@ type CreateDogfoodProjectParams struct {
 	CookieDomain        string
 }
 
-func (q *Queries) CreateDogfoodProject(ctx context.Context, arg CreateDogfoodProjectParams) (Project, error) {
-	row := q.db.QueryRow(ctx, createDogfoodProject,
+func (q *Queries) CreateConsoleProject(ctx context.Context, arg CreateConsoleProjectParams) (Project, error) {
+	row := q.db.QueryRow(ctx, createConsoleProject,
 		arg.ID,
 		arg.DisplayName,
 		arg.RedirectUri,

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -14,7 +14,7 @@ import (
 
 type Store struct {
 	db                                    *pgxpool.Pool
-	dogfoodProjectID                      *uuid.UUID
+	consoleProjectID                      *uuid.UUID
 	intermediateSessionSigningKeyKMSKeyID string
 	kms                                   *kms.Client
 	pageEncoder                           pagetoken.Encoder
@@ -24,7 +24,7 @@ type Store struct {
 
 type NewStoreParams struct {
 	DB                                    *pgxpool.Pool
-	DogfoodProjectID                      *uuid.UUID
+	ConsoleProjectID                      *uuid.UUID
 	IntermediateSessionSigningKeyKMSKeyID string
 	KMS                                   *kms.Client
 	PageEncoder                           pagetoken.Encoder
@@ -34,7 +34,7 @@ type NewStoreParams struct {
 func New(p NewStoreParams) *Store {
 	store := &Store{
 		db:                                    p.DB,
-		dogfoodProjectID:                      p.DogfoodProjectID,
+		consoleProjectID:                      p.ConsoleProjectID,
 		intermediateSessionSigningKeyKMSKeyID: p.IntermediateSessionSigningKeyKMSKeyID,
 		kms:                                   p.KMS,
 		pageEncoder:                           p.PageEncoder,

--- a/internal/storetesting/storetesting.go
+++ b/internal/storetesting/storetesting.go
@@ -20,8 +20,8 @@ type Environment struct {
 	KMS *testKms
 	S3  *testS3
 
-	DogfoodProjectID   *uuid.UUID
-	DogfoodUserID      string
+	ConsoleProjectID   *uuid.UUID
+	ConsoleUserID      string
 	ConsoleDomain      string
 	AuthAppsRootDomain string
 }
@@ -48,12 +48,12 @@ func NewEnvironment() (*Environment, func()) {
 
 func (e *Environment) seed() {
 	var (
-		dogfoodProjectID = uuid.MustParse("252491cc-76e3-4957-ab23-47d83c34f240")
-		dogfoodUserID    = uuid.MustParse("e071bbfe-6f27-4526-ab37-0ad251742836")
+		consoleProjectID = uuid.MustParse("252491cc-76e3-4957-ab23-47d83c34f240")
+		consoleUserID    = uuid.MustParse("e071bbfe-6f27-4526-ab37-0ad251742836")
 	)
 
-	e.DogfoodProjectID = &dogfoodProjectID
-	e.DogfoodUserID = idformat.User.Format(dogfoodUserID)
+	e.ConsoleProjectID = &consoleProjectID
+	e.ConsoleUserID = idformat.User.Format(consoleUserID)
 	e.ConsoleDomain = "console.tesseral.example.com"
 	e.AuthAppsRootDomain = "tesseral.example.app"
 
@@ -68,17 +68,17 @@ VALUES
     (gen_random_uuid(), '252491cc-76e3-4957-ab23-47d83c34f240', 'vault.console.tesseral.example.com'),
     (gen_random_uuid(), '252491cc-76e3-4957-ab23-47d83c34f240', 'console.tesseral.example.com');
 
--- Create the Dogfood Project's backing organization
+-- Create the Console Project's backing organization
 INSERT INTO organizations (id, display_name, project_id, log_in_with_google, log_in_with_microsoft, log_in_with_email, log_in_with_password, log_in_with_saml, log_in_with_authenticator_app, log_in_with_passkey, scim_enabled)
   VALUES ('7a76decb-6d79-49ce-9449-34fcc53151df'::uuid, 'project_54vwf0clhh0caqe20eujxgpeq Backing Organization', '252491cc-76e3-4957-ab23-47d83c34f240', false, false, false, false, false, false, false, false);
 
 UPDATE projects SET organization_id = '7a76decb-6d79-49ce-9449-34fcc53151df'::uuid where id = '252491cc-76e3-4957-ab23-47d83c34f240'::uuid;
 
--- Create project UI settings for the dogfood project
+-- Create project UI settings for the console project
 INSERT INTO project_ui_settings (id, project_id)
   VALUES (gen_random_uuid(), '252491cc-76e3-4957-ab23-47d83c34f240'::uuid);
 
--- Create a user in the dogfood project
+-- Create a user in the console project
 INSERT INTO users (id, email, password_bcrypt, organization_id, is_owner)
   VALUES ('e071bbfe-6f27-4526-ab37-0ad251742836'::uuid, 'root@app.tesseral.example.com', crypt('password', gen_salt('bf', 14)), '7a76decb-6d79-49ce-9449-34fcc53151df', true);
 `
@@ -102,7 +102,7 @@ INSERT INTO organizations (id, display_name, project_id, log_in_with_google, log
 `,
 		organizationID.String(),
 		fmt.Sprintf("%s Backing Organization", formattedProjectID),
-		*e.DogfoodProjectID,
+		*e.ConsoleProjectID,
 	)
 	if err != nil {
 		t.Fatalf("failed to create backing organization for test project: %v", err)

--- a/sqlc/queries.sql
+++ b/sqlc/queries.sql
@@ -4,7 +4,7 @@ INSERT INTO organizations (id, project_id, display_name, scim_enabled, log_in_wi
 RETURNING
     *;
 
--- name: CreateDogfoodProject :one
+-- name: CreateConsoleProject :one
 INSERT INTO projects (id, display_name, redirect_uri, log_in_with_google, log_in_with_microsoft, log_in_with_email, log_in_with_password, vault_domain, email_send_from_domain, cookie_domain)
     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
 RETURNING


### PR DESCRIPTION
This PR updates all references to `DOGFOOD` to `CONSOLE`, `Dogfood` to `Console`, and `dogfood` to `console`. This is across all services and static files.

This is in preparation for a the console configuration discovery PR to minimize the amount of double work required as we roll out self-hosting support.

Tested against `dev1`.

NOTE: This change requires environment variable updates via terraform. These changes have already been applied in all environments, so the service is safe to release.