### PR TITLE
[OPEN-594] Load console vault domain through static file, instead at build-time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,4 @@ node_modules
 /console/public/index.css
 /console/public/index.js
 /console/public/index.js.map
-/console/config.json
+/console/public/config.json

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ node_modules
 /console/public/index.css
 /console/public/index.js
 /console/public/index.js.map
+/console/config.json

--- a/console/build.mjs
+++ b/console/build.mjs
@@ -1,4 +1,5 @@
 import * as esbuild from "esbuild";
+import * as fs from "fs";
 import { configDotenv } from "dotenv";
 
 const CONSOLE_BUILD_IS_DEV = process.env.CONSOLE_BUILD_IS_DEV === "1";
@@ -7,15 +8,15 @@ if (CONSOLE_BUILD_IS_DEV) {
   configDotenv({
     path: "./.env",
   });
+
+  const config = {
+    CONSOLE_API_URL: process.env.CONSOLE_API_URL,
+  };
+  fs.writeFileSync("./public/config.json", JSON.stringify(config, null, 2));
 }
 
 const context = await esbuild.context({
   bundle: true,
-  define: {
-    __REPLACED_BY_ESBUILD_API_URL__: JSON.stringify(
-      process.env.CONSOLE_API_URL,
-    ),
-  },
   entryPoints: ["./src"],
   minify: !CONSOLE_BUILD_IS_DEV,
   outfile: "./public/index.js",
@@ -25,6 +26,7 @@ const context = await esbuild.context({
 
 if (CONSOLE_BUILD_IS_DEV) {
   console.log("watching");
+
   await context.watch();
 } else {
   await context.rebuild();

--- a/console/public/config.json
+++ b/console/public/config.json
@@ -1,0 +1,3 @@
+{
+  "CONSOLE_API_URL": "https://vault.console.tesseral.example.com"
+}

--- a/console/public/config.json
+++ b/console/public/config.json
@@ -1,3 +1,0 @@
-{
-  "CONSOLE_API_URL": "https://vault.console.tesseral.example.com"
-}

--- a/console/src/App.tsx
+++ b/console/src/App.tsx
@@ -6,6 +6,7 @@ import { BrowserRouter, Navigate, Route, Routes } from "react-router";
 import { Toaster } from "sonner";
 
 import { PageShell } from "@/components/page";
+import { ConsoleApiUrlProvider, useConsoleApiUrl } from "@/lib/console-api-url";
 import { NotFoundPage } from "@/pages/NotFoundPage";
 import { HomePage } from "@/pages/console/home/HomePage";
 import { ListOrganizationsPage } from "@/pages/console/organizations/ListOrganizationsPage";
@@ -15,7 +16,6 @@ import { OrganizationUsersTab } from "@/pages/console/organizations/Organization
 import { UserDetailsTab } from "@/pages/console/organizations/users/UserDetailsTab";
 import { UserPage } from "@/pages/console/organizations/users/UserPage";
 
-import { API_URL } from "./config";
 import { ConsoleConfigurationProvider } from "./lib/console-configuration";
 import { OrganizationApiKeysTab } from "./pages/console/organizations/OrganizationApiKeysTab";
 import { OrganizationAuthentication } from "./pages/console/organizations/OrganizationAuthenticationTab";
@@ -74,228 +74,219 @@ import { VerifyPasskeyPage } from "./pages/login/VerifyPasskeyPage";
 import { VerifyPasswordPage } from "./pages/login/VerifyPasswordPage";
 import { VerifySecondaryFactorPage } from "./pages/login/VerifySecondaryFactorPage";
 
-const queryClient = new QueryClient();
-
-const transport = createConnectTransport({
-  baseUrl: `${API_URL}/api/internal/connect`,
-  fetch: (input, init) =>
-    fetch(input, {
-      ...init,
-      credentials: "include",
-    }),
-});
-
 function AppWithinQueryClient() {
-  return (
-    <TransportProvider transport={transport}>
-      <ConsoleConfigurationProvider>
+    return (
         <BrowserRouter>
-          <Routes>
-            <Route
-              path="/project-settings"
-              element={<Navigate to="/settings/vault/domains" replace />}
-            />
-            <Route
-              path="/project-settings/publishable-keys"
-              element={<Navigate to="/settings/api-keys" replace />}
-            />
-
-            {/* Console Routes */}
-            <Route path="/" element={<PageShell />}>
-              <Route path="" element={<HomePage />} />
-
-              <Route path="organizations">
-                <Route path="" element={<ListOrganizationsPage />} />
-                <Route path=":organizationId" element={<OrganizationPage />}>
-                  <Route path="" element={<OrganizationDetailsTab />} />
-                  <Route
-                    path="authentication"
-                    element={<OrganizationAuthentication />}
-                  />
-                  <Route path="api-keys" element={<OrganizationApiKeysTab />} />
-                  <Route path="users" element={<OrganizationUsersTab />} />
-
-                  <Route path="logs" element={<OrganizationLogs />} />
-                </Route>
-              </Route>
-
-              <Route
-                path="organizations/:organizationId/users/:userId"
-                element={<UserPage />}
-              >
-                <Route path="" element={<UserDetailsTab />} />
-                <Route path="sessions" element={<UserSessionsTab />} />
-                <Route path="roles" element={<UserRolesTab />} />
-                <Route path="passkeys" element={<UserPasskeysTab />} />
-                <Route path="history" element={<UserHistoryTab />} />
-                <Route path="activity" element={<UserActivityTab />} />
-              </Route>
-
-              <Route
-                path="organizations/:organizationId/users/:userId/passkeys/:passkeyId"
-                element={<PasskeyPage />}
-              />
-
-              <Route
-                path="organizations/:organizationId/users/:userId/sessions/:sessionId"
-                element={<SessionPage />}
-              />
-
-              <Route
-                path="organizations/:organizationId/api-keys/:apiKeyId"
-                element={<OrganizationApiKeyPage />}
-              >
-                <Route path="" element={<OrganizationApiKeyDetailsTab />} />
-                <Route path="roles" element={<OrganizationApiKeyRolesTab />} />
-                <Route path="logs" element={<OrganizationApiKeyLogsTab />} />
-              </Route>
-
-              <Route
-                path="organizations/:organizationId/saml-connections/:samlConnectionId"
-                element={<OrganizationSamlConnectionPage />}
-              />
-
-              <Route
-                path="organizations/:organizationId/oidc-connections/:oidcConnectionId"
-                element={<OrganizationOidcConnectionPage />}
-              />
-
-              <Route
-                path="organizations/:organizationId/scim-api-keys/:scimApiKeyId"
-                element={<OrganizationScimApiKeyPage />}
-              >
-                <Route path="" element={<OrganizationScimApiKeyDetailsTab />} />
+            <Routes>
                 <Route
-                  path="logs"
-                  element={<OrganizationScimApiKeyLogsTab />}
+                    path="/project-settings"
+                    element={<Navigate to="/settings/vault/domains" replace />}
                 />
-              </Route>
-
-              <Route path="settings">
-                <Route path="" element={<SettingsOverviewPage />} />
                 <Route
-                  path="authentication"
-                  element={<AuthenticationSettingsPage />}
+                    path="/project-settings/publishable-keys"
+                    element={<Navigate to="/settings/api-keys" replace />}
                 />
-                <Route path="api-keys" element={<ApiKeySettingsPage />} />
-                <Route path="api-keys/backend-api-keys">
-                  <Route path="" element={<BackendApiKeysPage />} />
-                  <Route
-                    path=":backendApiKeyId"
-                    element={<BackendApiKeyPage />}
-                  />
+
+                {/* Console Routes */}
+                <Route path="/" element={<PageShell />}>
+                    <Route path="" element={<HomePage />} />
+
+                    <Route path="organizations">
+                        <Route path="" element={<ListOrganizationsPage />} />
+                        <Route path=":organizationId" element={<OrganizationPage />}>
+                            <Route path="" element={<OrganizationDetailsTab />} />
+                            <Route
+                                path="authentication"
+                                element={<OrganizationAuthentication />}
+                            />
+                            <Route path="api-keys" element={<OrganizationApiKeysTab />} />
+                            <Route path="users" element={<OrganizationUsersTab />} />
+
+                            <Route path="logs" element={<OrganizationLogs />} />
+                        </Route>
+                    </Route>
+
+                    <Route
+                        path="organizations/:organizationId/users/:userId"
+                        element={<UserPage />}
+                    >
+                        <Route path="" element={<UserDetailsTab />} />
+                        <Route path="sessions" element={<UserSessionsTab />} />
+                        <Route path="roles" element={<UserRolesTab />} />
+                        <Route path="passkeys" element={<UserPasskeysTab />} />
+                        <Route path="history" element={<UserHistoryTab />} />
+                        <Route path="activity" element={<UserActivityTab />} />
+                    </Route>
+
+                    <Route
+                        path="organizations/:organizationId/users/:userId/passkeys/:passkeyId"
+                        element={<PasskeyPage />}
+                    />
+
+                    <Route
+                        path="organizations/:organizationId/users/:userId/sessions/:sessionId"
+                        element={<SessionPage />}
+                    />
+
+                    <Route
+                        path="organizations/:organizationId/api-keys/:apiKeyId"
+                        element={<OrganizationApiKeyPage />}
+                    >
+                        <Route path="" element={<OrganizationApiKeyDetailsTab />} />
+                        <Route path="roles" element={<OrganizationApiKeyRolesTab />} />
+                        <Route path="logs" element={<OrganizationApiKeyLogsTab />} />
+                    </Route>
+
+                    <Route
+                        path="organizations/:organizationId/saml-connections/:samlConnectionId"
+                        element={<OrganizationSamlConnectionPage />}
+                    />
+
+                    <Route
+                        path="organizations/:organizationId/oidc-connections/:oidcConnectionId"
+                        element={<OrganizationOidcConnectionPage />}
+                    />
+
+                    <Route
+                        path="organizations/:organizationId/scim-api-keys/:scimApiKeyId"
+                        element={<OrganizationScimApiKeyPage />}
+                    >
+                        <Route path="" element={<OrganizationScimApiKeyDetailsTab />} />
+                        <Route path="logs" element={<OrganizationScimApiKeyLogsTab />} />
+                    </Route>
+
+                    <Route path="settings">
+                        <Route path="" element={<SettingsOverviewPage />} />
+                        <Route
+                            path="authentication"
+                            element={<AuthenticationSettingsPage />}
+                        />
+                        <Route path="api-keys" element={<ApiKeySettingsPage />} />
+                        <Route path="api-keys/backend-api-keys">
+                            <Route path="" element={<BackendApiKeysPage />} />
+                            <Route path=":backendApiKeyId" element={<BackendApiKeyPage />} />
+                        </Route>
+
+                        <Route path="access" element={<AccessSettingsPage />} />
+                        <Route path="vault" element={<VaultCustomizationPage />}>
+                            <Route path="" element={<VaultDetailsTab />} />
+                            <Route path="domains" element={<VaultDomainSettingsTab />} />
+                            <Route path="branding" element={<VaultBrandingSettingsTab />} />
+                        </Route>
+                    </Route>
+
+                    <Route
+                        path="stripe-checkout-success"
+                        element={<StripeCheckoutSuccessPage />}
+                    />
                 </Route>
 
-                <Route path="access" element={<AccessSettingsPage />} />
-                <Route path="vault" element={<VaultCustomizationPage />}>
-                  <Route path="" element={<VaultDetailsTab />} />
-                  <Route path="domains" element={<VaultDomainSettingsTab />} />
-                  <Route
-                    path="branding"
-                    element={<VaultBrandingSettingsTab />}
-                  />
+                {/* Login and Signup Routes */}
+                <Route path="login" element={<LoginPage />} />
+                <Route path="signup" element={<SignupPage />} />
+
+                <Route path="" element={<LoginFlowLayout />}>
+                    <Route path="verify-email" element={<VerifyEmailPage />} />
+                    <Route
+                        path="github-oauth-callback"
+                        element={<GithubOAuthCallbackPage />}
+                    />
+                    <Route
+                        path="google-oauth-callback"
+                        element={<GoogleOAuthCallbackPage />}
+                    />
+                    <Route
+                        path="microsoft-oauth-callback"
+                        element={<MicrosoftOAuthCallbackPage />}
+                    />
+                    <Route path="choose-organization" element={<ChooseProjectPage />} />
+                    <Route path="create-organization" element={<CreateProjectPage />} />
+                    <Route
+                        path="create-sandbox-project"
+                        element={<CreateSandboxProjectPage />}
+                    />
+                    <Route
+                        path="organizations/:organizationId/login"
+                        element={<OrganizationLoginPage />}
+                    />
+                    <Route
+                        path="authenticate-another-way"
+                        element={<AuthenticateAnotherWayPage />}
+                    />
+                    <Route path="verify-password" element={<VerifyPasswordPage />} />
+                    <Route path="forgot-password" element={<ForgotPasswordPage />} />
+                    <Route
+                        path="verify-secondary-factor"
+                        element={<VerifySecondaryFactorPage />}
+                    />
+                    <Route
+                        path="verify-authenticator-app"
+                        element={<VerifyAuthenticatorAppPage />}
+                    />
+                    <Route
+                        path="verify-authenticator-app-recovery-code"
+                        element={<VerifyAuthenticatorAppRecoveryCodePage />}
+                    />
+                    <Route path="verify-passkey" element={<VerifyPasskeyPage />} />
+                    <Route path="register-password" element={<RegisterPasswordPage />} />
+                    <Route
+                        path="register-secondary-factor"
+                        element={<RegisterSecondaryFactorPage />}
+                    />
+                    <Route path="register-passkey" element={<RegisterPasskeyPage />} />
+                    <Route
+                        path="register-authenticator-app"
+                        element={<RegisterAuthenticatorAppPage />}
+                    />
+                    <Route path="finish-login" element={<FinishLoginPage />} />
+
+                    <Route path="impersonate" element={<ImpersonatePage />} />
+                    <Route
+                        path="switch-organizations/:organizationId"
+                        element={<SwitchOrganizationsPage />}
+                    />
+
+                    <Route path="logout" element={<LogoutPage />} />
                 </Route>
-              </Route>
 
-              <Route
-                path="stripe-checkout-success"
-                element={<StripeCheckoutSuccessPage />}
-              />
-            </Route>
-
-            {/* Login and Signup Routes */}
-            <Route path="login" element={<LoginPage />} />
-            <Route path="signup" element={<SignupPage />} />
-
-            <Route path="" element={<LoginFlowLayout />}>
-              <Route path="verify-email" element={<VerifyEmailPage />} />
-              <Route
-                path="github-oauth-callback"
-                element={<GithubOAuthCallbackPage />}
-              />
-              <Route
-                path="google-oauth-callback"
-                element={<GoogleOAuthCallbackPage />}
-              />
-              <Route
-                path="microsoft-oauth-callback"
-                element={<MicrosoftOAuthCallbackPage />}
-              />
-              <Route
-                path="choose-organization"
-                element={<ChooseProjectPage />}
-              />
-              <Route
-                path="create-organization"
-                element={<CreateProjectPage />}
-              />
-              <Route
-                path="create-sandbox-project"
-                element={<CreateSandboxProjectPage />}
-              />
-              <Route
-                path="organizations/:organizationId/login"
-                element={<OrganizationLoginPage />}
-              />
-              <Route
-                path="authenticate-another-way"
-                element={<AuthenticateAnotherWayPage />}
-              />
-              <Route path="verify-password" element={<VerifyPasswordPage />} />
-              <Route path="forgot-password" element={<ForgotPasswordPage />} />
-              <Route
-                path="verify-secondary-factor"
-                element={<VerifySecondaryFactorPage />}
-              />
-              <Route
-                path="verify-authenticator-app"
-                element={<VerifyAuthenticatorAppPage />}
-              />
-              <Route
-                path="verify-authenticator-app-recovery-code"
-                element={<VerifyAuthenticatorAppRecoveryCodePage />}
-              />
-              <Route path="verify-passkey" element={<VerifyPasskeyPage />} />
-              <Route
-                path="register-password"
-                element={<RegisterPasswordPage />}
-              />
-              <Route
-                path="register-secondary-factor"
-                element={<RegisterSecondaryFactorPage />}
-              />
-              <Route
-                path="register-passkey"
-                element={<RegisterPasskeyPage />}
-              />
-              <Route
-                path="register-authenticator-app"
-                element={<RegisterAuthenticatorAppPage />}
-              />
-              <Route path="finish-login" element={<FinishLoginPage />} />
-
-              <Route path="impersonate" element={<ImpersonatePage />} />
-              <Route
-                path="switch-organizations/:organizationId"
-                element={<SwitchOrganizationsPage />}
-              />
-
-              <Route path="logout" element={<LogoutPage />} />
-            </Route>
-
-            <Route path="*" element={<NotFoundPage />} />
-          </Routes>
+                <Route path="*" element={<NotFoundPage />} />
+            </Routes>
         </BrowserRouter>
-      </ConsoleConfigurationProvider>
-    </TransportProvider>
-  );
+    );
+}
+
+function QueryClientProviderWrapper({
+                                        children,
+                                    }: {
+    children: React.ReactNode;
+}) {
+    const apiUrl = useConsoleApiUrl();
+    const transport = createConnectTransport({
+        baseUrl: `${apiUrl}/api/internal/connect`,
+        fetch: (input, init) =>
+            fetch(input, {
+                ...init,
+                credentials: "include",
+            }),
+    });
+    const queryClient = new QueryClient();
+
+    return (
+        <QueryClientProvider client={queryClient}>
+            <TransportProvider transport={transport}>{children}</TransportProvider>
+        </QueryClientProvider>
+    );
 }
 
 export function App() {
-  return (
-    <QueryClientProvider client={queryClient}>
-      <AppWithinQueryClient />
-      <Toaster />
-    </QueryClientProvider>
-  );
+    return (
+        <ConsoleApiUrlProvider>
+            <QueryClientProviderWrapper>
+                <ConsoleConfigurationProvider>
+                    <AppWithinQueryClient />
+                    <Toaster />
+                </ConsoleConfigurationProvider>
+            </QueryClientProviderWrapper>
+        </ConsoleApiUrlProvider>
+    );
 }

--- a/console/src/components/page/Navigation.tsx
+++ b/console/src/components/page/Navigation.tsx
@@ -21,7 +21,7 @@ import {
   Vault,
   Webhook,
 } from "lucide-react";
-import React, { Dispatch, SetStateAction, useState } from "react";
+import React, { Dispatch, SetStateAction, useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 import { Link, useLocation, useNavigate } from "react-router-dom";
 import { toast } from "sonner";
@@ -46,7 +46,6 @@ import {
   NavigationMenuTrigger,
   navigationMenuTriggerStyle,
 } from "@/components/ui/navigation-menu";
-import { API_URL } from "@/config";
 import {
   consoleCreateProject,
   getProject,
@@ -626,6 +625,14 @@ function NavigationUser() {
     navigate("/login");
   }
 
+  const [apiUrl, setApiUrl] = useState("");
+  useEffect(() => {
+    (async () => {
+      const config = await (await fetch("/config.json")).json();
+      setApiUrl(config.CONSOLE_API_URL);
+    })();
+  }, []);
+
   return (
     <DropdownMenu>
       <DropdownMenuTrigger className="inline-flex items-center">
@@ -657,13 +664,13 @@ function NavigationUser() {
         <DropdownMenuGroup>
           <DropdownMenuLabel>Settings</DropdownMenuLabel>
           <DropdownMenuItem>
-            <Link to={`${API_URL}/user-settings`}>
+            <Link to={`${apiUrl}/user-settings`}>
               <User className="inline max-h-4 mr-2" />
               User Settings
             </Link>
           </DropdownMenuItem>
           <DropdownMenuItem>
-            <Link to={`${API_URL}/organization-settings`}>
+            <Link to={`${apiUrl}/organization-settings`}>
               <Building2 className="inline max-h-4 mr-2" />
               Organization Settings
             </Link>

--- a/console/src/config.ts
+++ b/console/src/config.ts
@@ -1,2 +1,0 @@
-// @ts-expect-error esbuild replaces this at build time, but tsc-check doesn't know that
-export const API_URL = __REPLACED_BY_ESBUILD_API_URL__;

--- a/console/src/lib/console-api-url.tsx
+++ b/console/src/lib/console-api-url.tsx
@@ -1,0 +1,45 @@
+import React, {
+  PropsWithChildren,
+  createContext,
+  useContext,
+  useEffect,
+  useState,
+} from "react";
+
+const Context = createContext<string | undefined>(undefined);
+
+export function ConsoleApiUrlProvider({ children }: PropsWithChildren) {
+  const [apiUrl, setApiUrl] = useState<string | undefined>(undefined);
+
+  useEffect(() => {
+    const fetchConfig = async () => {
+      try {
+        const response = await fetch("/config.json");
+        if (response.ok) {
+          const config = await response.json();
+          setApiUrl(config.CONSOLE_API_URL);
+        }
+      } catch (error) {
+        console.error("Failed to fetch config.json:", error);
+      }
+    };
+
+    fetchConfig();
+  }, []);
+
+  if (!apiUrl) {
+    return null;
+  }
+
+  return <Context.Provider value={apiUrl}>{children}</Context.Provider>;
+}
+
+export function useConsoleApiUrl(): string {
+  const apiUrl = useContext(Context);
+  if (!apiUrl) {
+    throw new Error(
+      "useConsoleApiUrl must be used within a ConsoleApiUrlProvider",
+    );
+  }
+  return apiUrl;
+}


### PR DESCRIPTION
This PR moves how the Console loads its vault domain from being based on esbuild to instead loading from a static file at `/config.json`. 

This is in service of making self-hosting easier, by removing a configuration-time dependency on esbuild. We can now ship a mostly complete build of the Console, and the only final step is serving a correct `/config.json`, which can easily happen without a bundler.