### PR TITLE
Show SCIM Base URL on SCIM API Keys, fix typography + copy

### DIFF
--- a/console/src/pages/console/organizations/saml-connections/OrganizationSamlConnectionPage.tsx
+++ b/console/src/pages/console/organizations/saml-connections/OrganizationSamlConnectionPage.tsx
@@ -175,7 +175,7 @@ export function OrganizationSamlConnectionPage() {
             </CardHeader>
             <CardContent className="space-y-4">
               <div className="space-y-2">
-                <div className="font-semibold">
+                <div className="font-medium text-sm">
                   Assertion Consumer Service (ACS) URL
                 </div>
                 <ValueCopier
@@ -186,7 +186,7 @@ export function OrganizationSamlConnectionPage() {
                 />
               </div>
               <div className="space-y-2">
-                <div className="font-semibold">SP Entity ID</div>
+                <div className="font-medium text-sm">SP Entity ID</div>
                 <ValueCopier
                   value={
                     getSamlConnectionResponse?.samlConnection?.spEntityId || ""

--- a/console/src/pages/console/organizations/scim-api-keys/OrganizationScimApiKeyDetailsTab.tsx
+++ b/console/src/pages/console/organizations/scim-api-keys/OrganizationScimApiKeyDetailsTab.tsx
@@ -7,6 +7,7 @@ import { useNavigate, useParams } from "react-router";
 import { toast } from "sonner";
 import { z } from "zod";
 
+import { ValueCopier } from "@/components/core/ValueCopier";
 import {
   AlertDialog,
   AlertDialogContent,
@@ -36,6 +37,7 @@ import {
 import { Input } from "@/components/ui/input";
 import {
   deleteSCIMAPIKey,
+  getProject,
   getSCIMAPIKey,
   revokeSCIMAPIKey,
   updateSCIMAPIKey,
@@ -47,6 +49,8 @@ const schema = z.object({
 
 export function OrganizationScimApiKeyDetailsTab() {
   const { scimApiKeyId } = useParams();
+
+  const { data: getProjectResponse } = useQuery(getProject);
 
   const { data: getScimApiKeyResponse, refetch } = useQuery(getSCIMAPIKey, {
     id: scimApiKeyId,
@@ -133,6 +137,26 @@ export function OrganizationScimApiKeyDetailsTab() {
           </Card>
         </form>
       </Form>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Service Provider Details</CardTitle>
+          <CardDescription>
+            The configuration here is assigned automatically by Tesseral, and
+            needs to be inputted into your customer's Identity Provider by their
+            IT admin.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-2">
+            <div className="font-medium text-sm">SCIM Base URL</div>
+            <ValueCopier
+              value={`https://${getProjectResponse?.project?.vaultDomain}/api/scim/v1`}
+              label="SCIM Base URL"
+            />
+          </div>
+        </CardContent>
+      </Card>
 
       <DangerZoneCard />
     </div>

--- a/vault-ui/src/pages/vault/organization/saml-connections/SamlConnectionPage.tsx
+++ b/vault-ui/src/pages/vault/organization/saml-connections/SamlConnectionPage.tsx
@@ -165,37 +165,6 @@ export function SamlConnectionPage() {
         </Link>
       </div>
 
-      <Card>
-        <CardHeader>
-          <CardTitle>Service Provider Details</CardTitle>
-          <CardDescription>
-            The configuration here is assigned automatically by Tesseral, and
-            needs to be inputted into your customer's Identity Provider by their
-            IT admin.
-          </CardDescription>
-        </CardHeader>
-        <CardContent className="space-y-4">
-          <div className="space-y-2">
-            <div className="font-semibold">
-              Assertion Consumer Service (ACS) URL
-            </div>
-            <ValueCopier
-              value={getSamlConnectionResponse?.samlConnection?.spAcsUrl || ""}
-              label="ACS URL"
-            />
-          </div>
-          <div className="space-y-2">
-            <div className="font-semibold">SP Entity ID</div>
-            <ValueCopier
-              value={
-                getSamlConnectionResponse?.samlConnection?.spEntityId || ""
-              }
-              label="SP Entity ID"
-            />
-          </div>
-        </CardContent>
-      </Card>
-
       <Form {...form}>
         <form onSubmit={form.handleSubmit(handleSubmit)}>
           <Card>
@@ -327,6 +296,36 @@ export function SamlConnectionPage() {
           </Card>
         </form>
       </Form>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Service Provider Details</CardTitle>
+          <CardDescription>
+            The configuration here needs to be inputted into your Identity
+            Provider.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="space-y-2">
+            <div className="font-medium text-sm">
+              Assertion Consumer Service (ACS) URL
+            </div>
+            <ValueCopier
+              value={getSamlConnectionResponse?.samlConnection?.spAcsUrl || ""}
+              label="ACS URL"
+            />
+          </div>
+          <div className="space-y-2">
+            <div className="font-medium text-sm">SP Entity ID</div>
+            <ValueCopier
+              value={
+                getSamlConnectionResponse?.samlConnection?.spEntityId || ""
+              }
+              label="SP Entity ID"
+            />
+          </div>
+        </CardContent>
+      </Card>
 
       <DangerZoneCard />
 

--- a/vault-ui/src/pages/vault/organization/scim-api-keys/ScimApiKeyPage.tsx
+++ b/vault-ui/src/pages/vault/organization/scim-api-keys/ScimApiKeyPage.tsx
@@ -52,6 +52,7 @@ import {
   revokeSCIMAPIKey,
   updateSCIMAPIKey,
 } from "@/gen/tesseral/frontend/v1/frontend-FrontendService_connectquery";
+import { useProjectSettings } from "@/lib/project-settings";
 
 const schema = z.object({
   displayName: z.string().min(1, "Display name is required"),
@@ -195,6 +196,27 @@ export function ScimApiKeyPage() {
           </Card>
         </form>
       </Form>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Service Provider Details</CardTitle>
+          <CardDescription>
+            The configuration here needs to be inputted into your Identity
+            Provider.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="space-y-2">
+            <div className="font-medium text-sm">
+              SCIM Base URL
+            </div>
+            <ValueCopier
+              value={`https://${location.host}/api/scim/v1`}
+              label="SCIM Base URL"
+            />
+          </div>
+        </CardContent>
+      </Card>
 
       <DangerZoneCard />
     </PageContent>


### PR DESCRIPTION
This PR shows the SCIM Base URL on the details view of SCIM API Keys, under a "Service Provider Details" card in both the Vault and the Console. It also makes tweaks to the copy and typography we use to show Service Provider Details for both SCIM API Keys and SAML Connections.

<img width="3840" height="1936" alt="screenshot-2025-07-31-10-06-57" src="https://github.com/user-attachments/assets/dfa2e9b0-9c8a-4b72-b7ba-7664c0cf02d5" />
<img width="3840" height="1936" alt="screenshot-2025-07-31-10-06-48" src="https://github.com/user-attachments/assets/7273d4e6-dd30-45a9-a98c-f350905cd6ba" />
<img width="3840" height="1936" alt="screenshot-2025-07-31-10-06-36" src="https://github.com/user-attachments/assets/aee42ab1-7010-4336-ac78-410215064e4b" />
<img width="3840" height="1936" alt="screenshot-2025-07-31-10-06-18" src="https://github.com/user-attachments/assets/0f6e7729-897b-4411-95c5-2a9b6128240e" />
