### PR TITLE
Add Docker builds for Console, Vault, Backend API, and Config API

### DIFF
--- a/.github/workflows/docker-images-stable.yml
+++ b/.github/workflows/docker-images-stable.yml
@@ -1,0 +1,195 @@
+name: Docker Images (Stable Channel)
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
+
+env:
+  IMAGE_PREFIX: ""
+  IMAGE_TAGS: type=semver,pattern={{version}}
+
+jobs:
+  tesseral-backend-api:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/tesseral-labs/${{ env.IMAGE_PREFIX }}tesseral-backend-api
+          tags: ${{ env.IMAGE_TAGS }}
+
+      - name: Build and push Docker image
+        id: push
+        uses: docker/build-push-action@v6
+        with:
+          context: cmd/tesseral-backend-api
+          file: cmd/tesseral-backend-api/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+      
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ghcr.io/tesseral-labs/${{ env.IMAGE_PREFIX }}tesseral-backend-api
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true
+
+  tesseral-config-api:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/tesseral-labs/${{ env.IMAGE_PREFIX }}tesseral-config-api
+          tags: ${{ env.IMAGE_TAGS }}
+
+      - name: Build and push Docker image
+        id: push
+        uses: docker/build-push-action@v6
+        with:
+          context: cmd/tesseral-config-api
+          file: cmd/tesseral-config-api/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ghcr.io/tesseral-labs/${{ env.IMAGE_PREFIX }}tesseral-config-api
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true
+
+  tesseral-console:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build Console assets
+        run: |
+          cd console
+          npm ci
+          npm run build
+          cp -r public ../cmd/tesseral-console/public
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/tesseral-labs/${{ env.IMAGE_PREFIX }}tesseral-console
+          tags: ${{ env.IMAGE_TAGS }}
+
+      - name: Build and push Docker image
+        id: push
+        uses: docker/build-push-action@v6
+        with:
+          context: cmd/tesseral-console
+          file: cmd/tesseral-console/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ghcr.io/tesseral-labs/${{ env.IMAGE_PREFIX }}tesseral-console
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true
+
+  tesseral-vault:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build Vault assets
+        run: |
+          cd vault-ui
+          npm ci
+          npm run build
+          cp -r public ../cmd/tesseral-vault/public
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/tesseral-labs/${{ env.IMAGE_PREFIX }}tesseral-vault
+          tags: ${{ env.IMAGE_TAGS }}
+
+      - name: Build and push Docker image
+        id: push
+        uses: docker/build-push-action@v6
+        with:
+          context: cmd/tesseral-vault
+          file: cmd/tesseral-vault/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ghcr.io/tesseral-labs/${{ env.IMAGE_PREFIX }}tesseral-vault
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true

--- a/.github/workflows/docker-images-unstable.yml
+++ b/.github/workflows/docker-images-unstable.yml
@@ -8,6 +8,10 @@ permissions:
   attestations: write
   id-token: write
 
+env:
+  IMAGE_PREFIX: unstable-
+  IMAGE_TAGS: type=sha
+
 jobs:
   tesseral-backend-api:
     runs-on: ubuntu-latest
@@ -26,7 +30,8 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ghcr.io/tesseral-labs/unstable-tesseral-backend-api
+          images: ghcr.io/tesseral-labs/${{ env.IMAGE_PREFIX }}tesseral-backend-api
+          tags: ${{ env.IMAGE_TAGS }}
 
       - name: Build and push Docker image
         id: push
@@ -41,6 +46,6 @@ jobs:
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v2
         with:
-          subject-name: ghcr.io/tesseral-labs/unstable-tesseral-backend-api
+          subject-name: ghcr.io/tesseral-labs/${{ env.IMAGE_PREFIX }}tesseral-backend-api
           subject-digest: ${{ steps.push.outputs.digest }}
           push-to-registry: true

--- a/.github/workflows/docker-images-unstable.yml
+++ b/.github/workflows/docker-images-unstable.yml
@@ -1,0 +1,46 @@
+name: Docker Images (Unstable Channel)
+
+on: [push]
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
+
+jobs:
+  tesseral-backend-api:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/tesseral-labs/unstable-tesseral-backend-api
+
+      - name: Build and push Docker image
+        id: push
+        uses: docker/build-push-action@v6
+        with:
+          context: cmd/tesseral-backend-api
+          file: cmd/tesseral-backend-api/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+      
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ghcr.io/tesseral-labs/unstable-tesseral-backend-api
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true

--- a/.github/workflows/docker-images-unstable.yml
+++ b/.github/workflows/docker-images-unstable.yml
@@ -19,6 +19,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Log in to the Container registry
         uses: docker/login-action@v3
         with:
@@ -39,6 +42,7 @@ jobs:
         with:
           context: cmd/tesseral-backend-api
           file: cmd/tesseral-backend-api/Dockerfile
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
@@ -55,6 +59,9 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
       - name: Log in to the Container registry
         uses: docker/login-action@v3
@@ -76,6 +83,7 @@ jobs:
         with:
           context: cmd/tesseral-config-api
           file: cmd/tesseral-config-api/Dockerfile
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
@@ -92,6 +100,9 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
       - name: Build Console assets
         run: |
@@ -120,6 +131,7 @@ jobs:
         with:
           context: cmd/tesseral-console
           file: cmd/tesseral-console/Dockerfile
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
@@ -136,6 +148,9 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
       - name: Build Vault assets
         run: |
@@ -164,6 +179,7 @@ jobs:
         with:
           context: cmd/tesseral-vault
           file: cmd/tesseral-vault/Dockerfile
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker-images-unstable.yml
+++ b/.github/workflows/docker-images-unstable.yml
@@ -96,6 +96,7 @@ jobs:
       - name: Build Console assets
         run: |
           cd console
+          npm ci
           npm run build
           cp -r public ../cmd/tesseral-console/public
 
@@ -139,6 +140,7 @@ jobs:
       - name: Build Vault assets
         run: |
           cd vault-ui
+          npm ci
           npm run build
           cp -r public ../cmd/tesseral-vault/public
 

--- a/.github/workflows/docker-images-unstable.yml
+++ b/.github/workflows/docker-images-unstable.yml
@@ -49,3 +49,126 @@ jobs:
           subject-name: ghcr.io/tesseral-labs/${{ env.IMAGE_PREFIX }}tesseral-backend-api
           subject-digest: ${{ steps.push.outputs.digest }}
           push-to-registry: true
+
+  tesseral-config-api:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/tesseral-labs/${{ env.IMAGE_PREFIX }}tesseral-config-api
+          tags: ${{ env.IMAGE_TAGS }}
+
+      - name: Build and push Docker image
+        id: push
+        uses: docker/build-push-action@v6
+        with:
+          context: cmd/tesseral-config-api
+          file: cmd/tesseral-config-api/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ghcr.io/tesseral-labs/${{ env.IMAGE_PREFIX }}tesseral-config-api
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true
+
+  tesseral-console:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Build Console assets
+        run: |
+          cd console
+          npm run build
+          cp -r public ../cmd/tesseral-console/public
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/tesseral-labs/${{ env.IMAGE_PREFIX }}tesseral-console
+          tags: ${{ env.IMAGE_TAGS }}
+
+      - name: Build and push Docker image
+        id: push
+        uses: docker/build-push-action@v6
+        with:
+          context: cmd/tesseral-console
+          file: cmd/tesseral-console/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ghcr.io/tesseral-labs/${{ env.IMAGE_PREFIX }}tesseral-console
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true
+
+  tesseral-vault:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Build Vault assets
+        run: |
+          cd vault-ui
+          npm run build
+          cp -r public ../cmd/tesseral-vault/public
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/tesseral-labs/${{ env.IMAGE_PREFIX }}tesseral-vault
+          tags: ${{ env.IMAGE_TAGS }}
+
+      - name: Build and push Docker image
+        id: push
+        uses: docker/build-push-action@v6
+        with:
+          context: cmd/tesseral-vault
+          file: cmd/tesseral-vault/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ghcr.io/tesseral-labs/${{ env.IMAGE_PREFIX }}tesseral-vault
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true

--- a/cmd/tesseral-backend-api/Dockerfile
+++ b/cmd/tesseral-backend-api/Dockerfile
@@ -1,0 +1,10 @@
+FROM nginx:1.29.0
+
+COPY nginx.conf.template /etc/nginx/nginx.conf.template
+COPY entrypoint /entrypoint
+
+RUN chmod +x /entrypoint
+
+EXPOSE 80
+
+ENTRYPOINT ["/entrypoint"]

--- a/cmd/tesseral-backend-api/entrypoint
+++ b/cmd/tesseral-backend-api/entrypoint
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+set -e
+
+envsubst '${TESSERAL_BACKEND_API_TESSERAL_INTERNAL_API_ENDPOINT}' < /etc/nginx/nginx.conf.template > /etc/nginx/nginx.conf
+
+exec nginx -g 'daemon off;'

--- a/cmd/tesseral-backend-api/nginx.conf.template
+++ b/cmd/tesseral-backend-api/nginx.conf.template
@@ -5,7 +5,7 @@ http {
         listen 80;
 
         location / {
-            proxy_pass ${TESSERAL_CONFIG_API_TESSERAL_INTERNAL_API_ENDPOINT}/api/config-api/;
+            proxy_pass ${TESSERAL_BACKEND_API_TESSERAL_INTERNAL_API_ENDPOINT}/api/backend/;
             proxy_ssl_server_name on;
         }
     }

--- a/cmd/tesseral-config-api/Dockerfile
+++ b/cmd/tesseral-config-api/Dockerfile
@@ -1,0 +1,10 @@
+FROM nginx:1.29.0
+
+COPY nginx.conf.template /etc/nginx/nginx.conf.template
+COPY entrypoint /entrypoint
+
+RUN chmod +x /entrypoint
+
+EXPOSE 80
+
+ENTRYPOINT ["/entrypoint"]

--- a/cmd/tesseral-config-api/entrypoint
+++ b/cmd/tesseral-config-api/entrypoint
@@ -2,6 +2,6 @@
 
 set -e
 
-envsubst '${TESSERAL_CONFIG_API_TESSERAL_INTERNAL_API}' < /etc/nginx/nginx.conf.template > /etc/nginx/nginx.conf
+envsubst '${TESSERAL_CONFIG_API_TESSERAL_INTERNAL_API_ENDPOINT}' < /etc/nginx/nginx.conf.template > /etc/nginx/nginx.conf
 
 exec nginx -g 'daemon off;'

--- a/cmd/tesseral-config-api/entrypoint
+++ b/cmd/tesseral-config-api/entrypoint
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+set -e
+
+envsubst '${TESSERAL_CONFIG_API_TESSERAL_INTERNAL_API}' < /etc/nginx/nginx.conf.template > /etc/nginx/nginx.conf
+
+exec nginx -g 'daemon off;'

--- a/cmd/tesseral-config-api/nginx.conf.template
+++ b/cmd/tesseral-config-api/nginx.conf.template
@@ -1,0 +1,12 @@
+events {}
+
+http {
+    server {
+        listen 80;
+
+        location / {
+            proxy_pass ${TESSERAL_CONFIG_API_TESSERAL_INTERNAL_API}/api/config-api/;
+            proxy_ssl_server_name on;
+        }
+    }
+}

--- a/cmd/tesseral-console/Dockerfile
+++ b/cmd/tesseral-console/Dockerfile
@@ -1,0 +1,8 @@
+FROM nginx:1.29.0
+
+COPY nginx.conf /etc/nginx/nginx.conf
+COPY public /www/public
+
+EXPOSE 80
+
+ENTRYPOINT ["nginx", "-g", "daemon off;"]

--- a/cmd/tesseral-console/Dockerfile
+++ b/cmd/tesseral-console/Dockerfile
@@ -2,7 +2,10 @@ FROM nginx:1.29.0
 
 COPY nginx.conf /etc/nginx/nginx.conf
 COPY public /www/public
+COPY entrypoint /entrypoint
+
+RUN chmod +x /entrypoint
 
 EXPOSE 80
 
-ENTRYPOINT ["nginx", "-g", "daemon off;"]
+ENTRYPOINT ["/entrypoint"]

--- a/cmd/tesseral-console/entrypoint
+++ b/cmd/tesseral-console/entrypoint
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+echo '{"CONSOLE_API_URL": "'"$TESSERAL_CONSOLE_VAULT_ENDPOINT"'"}' > /www/public/config.json
+
+exec nginx -g 'daemon off;'

--- a/cmd/tesseral-console/nginx.conf
+++ b/cmd/tesseral-console/nginx.conf
@@ -1,0 +1,12 @@
+events {}
+
+http {
+    server {
+        listen 80;
+
+        root /www/public;
+        index index.html;
+
+        try_files $uri $uri/ /index.html;
+    }
+}

--- a/cmd/tesseral-vault/Dockerfile
+++ b/cmd/tesseral-vault/Dockerfile
@@ -1,0 +1,11 @@
+FROM nginx:1.29.0
+
+COPY nginx.conf.template /etc/nginx/nginx.conf.template
+COPY entrypoint /entrypoint
+COPY public /www/public
+
+RUN chmod +x /entrypoint
+
+EXPOSE 80
+
+ENTRYPOINT ["/entrypoint"]

--- a/cmd/tesseral-vault/entrypoint
+++ b/cmd/tesseral-vault/entrypoint
@@ -2,10 +2,10 @@
 
 set -e
 
-# rewrite TESSERAL_VAULT_TRUSTED_HOSTNAME_HEADER from "X-Forwarded-Host" to "$http_x_forwarded_host"
-export TESSERAL_VAULT_TRUSTED_HOSTNAME_HEADER="http_$(echo "${TESSERAL_VAULT_TRUSTED_HOSTNAME_HEADER}" | tr '[:upper:]' '[:lower:]' | tr '-' '_')"
+# rewrite TESSERAL_VAULT_TRUSTED_HOST_HEADER from "X-Forwarded-Host" to "$http_x_forwarded_host"
+export TESSERAL_VAULT_TRUSTED_HOST_HEADER="http_$(echo "${TESSERAL_VAULT_TRUSTED_HOST_HEADER}" | tr '[:upper:]' '[:lower:]' | tr '-' '_')"
 
-envsubst '${TESSERAL_VAULT_TESSERAL_INTERNAL_API_ENDPOINT},${TESSERAL_VAULT_TRUSTED_HOSTNAME_HEADER}' < /etc/nginx/nginx.conf.template > /etc/nginx/nginx.conf
+envsubst '${TESSERAL_VAULT_TESSERAL_INTERNAL_API_ENDPOINT},${TESSERAL_VAULT_TRUSTED_HOST_HEADER}' < /etc/nginx/nginx.conf.template > /etc/nginx/nginx.conf
 
 cat /etc/nginx/nginx.conf
 exec nginx -g 'daemon off;'

--- a/cmd/tesseral-vault/entrypoint
+++ b/cmd/tesseral-vault/entrypoint
@@ -7,5 +7,4 @@ export TESSERAL_VAULT_TRUSTED_HOST_HEADER="http_$(echo "${TESSERAL_VAULT_TRUSTED
 
 envsubst '${TESSERAL_VAULT_TESSERAL_INTERNAL_API_ENDPOINT},${TESSERAL_VAULT_TRUSTED_HOST_HEADER}' < /etc/nginx/nginx.conf.template > /etc/nginx/nginx.conf
 
-cat /etc/nginx/nginx.conf
 exec nginx -g 'daemon off;'

--- a/cmd/tesseral-vault/entrypoint
+++ b/cmd/tesseral-vault/entrypoint
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+set -e
+
+# rewrite TESSERAL_VAULT_TRUSTED_HOSTNAME_HEADER from "X-Forwarded-Host" to "$http_x_forwarded_host"
+export TESSERAL_VAULT_TRUSTED_HOSTNAME_HEADER="http_$(echo "${TESSERAL_VAULT_TRUSTED_HOSTNAME_HEADER}" | tr '[:upper:]' '[:lower:]' | tr '-' '_')"
+
+envsubst '${TESSERAL_VAULT_TESSERAL_INTERNAL_API_ENDPOINT},${TESSERAL_VAULT_TRUSTED_HOSTNAME_HEADER}' < /etc/nginx/nginx.conf.template > /etc/nginx/nginx.conf
+
+cat /etc/nginx/nginx.conf
+exec nginx -g 'daemon off;'

--- a/cmd/tesseral-vault/nginx.conf.template
+++ b/cmd/tesseral-vault/nginx.conf.template
@@ -1,0 +1,20 @@
+events {}
+
+http {
+    server {
+        listen 80;
+
+        location / {
+            root /www/public;
+            index index.html;
+
+            try_files $uri $uri/ /index.html;
+        }
+
+        location /api/ {
+            proxy_set_header X-Tesseral-Host $${TESSERAL_VAULT_TRUSTED_HOSTNAME_HEADER};
+            proxy_pass ${TESSERAL_VAULT_TESSERAL_INTERNAL_API_ENDPOINT}/api/;
+            proxy_ssl_server_name on;
+        }
+    }
+}

--- a/cmd/tesseral-vault/nginx.conf.template
+++ b/cmd/tesseral-vault/nginx.conf.template
@@ -12,7 +12,7 @@ http {
         }
 
         location /api/ {
-            proxy_set_header X-Tesseral-Host $${TESSERAL_VAULT_TRUSTED_HOSTNAME_HEADER};
+            proxy_set_header X-Tesseral-Host $${TESSERAL_VAULT_TRUSTED_HOST_HEADER};
             proxy_pass ${TESSERAL_VAULT_TESSERAL_INTERNAL_API_ENDPOINT}/api/;
             proxy_ssl_server_name on;
         }


### PR DESCRIPTION
This PR adds Docker images, and CI to automatically build them, for Console, Vault, Backend API, and Config API. These are the auxiliary, mostly-just-nginx, supporting components that talk to the core Tesseral service.

This PR introduces two new CI workflows, one for "stable" releases and the other for "unstable" releases. These workflows are identical except for their trigger (tag pushes vs any push), the Docker tags they produce (semver vs SHA), and the names of the images (unprefixed vs prefixed with "unstable-").

Console does the typical 404-to-index SPA logic. Backend API and Config API are mostly proxies that prepend a prefix to requests. Vault does a combination of the two. All are nginx, with envsubst to allow self-hosters to configure where their internal Tesseral instance runs. 

A later PR will handle building and publishing the core Tesseral service itself.