### PR TITLE
[OPEN-586] Add update-project ctl command + bypass s3 with direct urls

### DIFF
--- a/cmd/openauthctl/main.go
+++ b/cmd/openauthctl/main.go
@@ -8,7 +8,7 @@ import (
 )
 
 func main() {
-	cli.Run(context.Background(), version, force, up, bootstrap)
+	cli.Run(context.Background(), version, force, up, bootstrap, updateProject)
 }
 
 type args struct {

--- a/cmd/openauthctl/migrations/000092_project_logo_urls.up.sql
+++ b/cmd/openauthctl/migrations/000092_project_logo_urls.up.sql
@@ -1,0 +1,3 @@
+alter table project_ui_settings
+    add column logo_url           varchar,
+    add column dark_mode_logo_url varchar;

--- a/cmd/openauthctl/update_project.go
+++ b/cmd/openauthctl/update_project.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/tesseral-labs/tesseral/internal/store"
+)
+
+type updateProjectArgs struct {
+	Args            args   `cli:"update-project,subcmd"`
+	ProjectID       string `cli:"project-id"`
+	Database        string `cli:"--database"`
+	VaultDomain     string `cli:"--vault-domain"`
+	LogoURL         string `cli:"--logo-url"`
+	DarkModeLogoURL string `cli:"--dark-mode-logo-url"`
+}
+
+func (updateProjectArgs) Description() string {
+	return "Update a Tesseral Project directly"
+}
+
+func (updateProjectArgs) ExtendedDescription() string {
+	return strings.TrimSpace(`
+Update a Tesseral Project directly, without the Tesseral Console or Backend API.
+`)
+}
+
+func updateProject(ctx context.Context, args updateProjectArgs) error {
+	db, err := pgxpool.New(context.Background(), args.Database)
+	if err != nil {
+		panic(err)
+	}
+
+	s := store.New(store.NewStoreParams{
+		DB: db,
+	})
+
+	if err := s.UpdateProject(ctx, &store.UpdateProjectRequest{
+		ProjectID:       args.ProjectID,
+		VaultDomain:     args.VaultDomain,
+		LogoURL:         args.LogoURL,
+		DarkModeLogoURL: args.DarkModeLogoURL,
+	}); err != nil {
+		return fmt.Errorf("store: %w", err)
+	}
+
+	return nil
+}

--- a/internal/auditlog/store/queries/models.go
+++ b/internal/auditlog/store/queries/models.go
@@ -438,6 +438,8 @@ type ProjectUiSetting struct {
 	AutoCreateOrganizations      bool
 	SelfServeCreateOrganizations bool
 	SelfServeCreateUsers         bool
+	LogoUrl                      *string
+	DarkModeLogoUrl              *string
 }
 
 type ProjectWebhookSetting struct {

--- a/internal/backend/store/project_ui_settings.go
+++ b/internal/backend/store/project_ui_settings.go
@@ -30,29 +30,39 @@ func (s *Store) GetProjectUISettings(ctx context.Context, req *backendv1.GetProj
 		return nil, fmt.Errorf("failed to get project ui settings: %w", err)
 	}
 
-	logoKey := fmt.Sprintf("vault-ui-settings-v1/%s/logo", idformat.Project.Format(projectID))
-	logoExists, err := s.getUserContentFileExists(ctx, logoKey)
-	if err != nil {
-		return nil, fmt.Errorf("failed to check if logo file exists: %w", err)
-	}
-	logoURL := ""
-	if logoExists {
-		logoURL, err = s.buildPresignedGetUrlForFile(ctx, logoKey)
+	var logoURL string
+	if qProjectUISettings.LogoUrl != nil {
+		logoURL = *qProjectUISettings.LogoUrl
+	} else {
+		logoKey := fmt.Sprintf("vault-ui-settings-v1/%s/logo", idformat.Project.Format(projectID))
+		logoExists, err := s.getUserContentFileExists(ctx, logoKey)
 		if err != nil {
-			return nil, fmt.Errorf("failed to build presigned URL for logo file: %w", err)
+			return nil, fmt.Errorf("failed to check if logo file exists: %w", err)
+		}
+
+		if logoExists {
+			logoURL, err = s.buildPresignedGetUrlForFile(ctx, logoKey)
+			if err != nil {
+				return nil, fmt.Errorf("failed to build presigned URL for logo file: %w", err)
+			}
 		}
 	}
 
-	darkModeLogoKey := fmt.Sprintf("vault-ui-settings-v1/%s/logo-dark", idformat.Project.Format(projectID))
-	darkModeLogoExists, err := s.getUserContentFileExists(ctx, darkModeLogoKey)
-	if err != nil {
-		return nil, fmt.Errorf("failed to check if dark mode logo file exists: %w", err)
-	}
-	darkModeLogoURL := ""
-	if darkModeLogoExists {
-		darkModeLogoURL, err = s.buildPresignedGetUrlForFile(ctx, darkModeLogoKey)
+	var darkModeLogoURL string
+	if qProjectUISettings.DarkModeLogoUrl != nil {
+		darkModeLogoURL = *qProjectUISettings.DarkModeLogoUrl
+	} else {
+		darkModeLogoKey := fmt.Sprintf("vault-ui-settings-v1/%s/logo-dark", idformat.Project.Format(projectID))
+		darkModeLogoExists, err := s.getUserContentFileExists(ctx, darkModeLogoKey)
 		if err != nil {
-			return nil, fmt.Errorf("failed to build presigned URL for dark mode logo file: %w", err)
+			return nil, fmt.Errorf("failed to check if dark mode logo file exists: %w", err)
+		}
+
+		if darkModeLogoExists {
+			darkModeLogoURL, err = s.buildPresignedGetUrlForFile(ctx, darkModeLogoKey)
+			if err != nil {
+				return nil, fmt.Errorf("failed to build presigned URL for dark mode logo file: %w", err)
+			}
 		}
 	}
 

--- a/internal/backend/store/queries/models.go
+++ b/internal/backend/store/queries/models.go
@@ -438,6 +438,8 @@ type ProjectUiSetting struct {
 	AutoCreateOrganizations      bool
 	SelfServeCreateOrganizations bool
 	SelfServeCreateUsers         bool
+	LogoUrl                      *string
+	DarkModeLogoUrl              *string
 }
 
 type ProjectWebhookSetting struct {

--- a/internal/backend/store/queries/queries-backend.sql.go
+++ b/internal/backend/store/queries/queries-backend.sql.go
@@ -655,7 +655,7 @@ const createProjectUISettings = `-- name: CreateProjectUISettings :one
 INSERT INTO project_ui_settings (id, project_id)
     VALUES (gen_random_uuid (), $1)
 RETURNING
-    id, project_id, primary_color, detect_dark_mode_enabled, dark_mode_primary_color, create_time, update_time, log_in_layout, auto_create_organizations, self_serve_create_organizations, self_serve_create_users
+    id, project_id, primary_color, detect_dark_mode_enabled, dark_mode_primary_color, create_time, update_time, log_in_layout, auto_create_organizations, self_serve_create_organizations, self_serve_create_users, logo_url, dark_mode_logo_url
 `
 
 func (q *Queries) CreateProjectUISettings(ctx context.Context, projectID uuid.UUID) (ProjectUiSetting, error) {
@@ -673,6 +673,8 @@ func (q *Queries) CreateProjectUISettings(ctx context.Context, projectID uuid.UU
 		&i.AutoCreateOrganizations,
 		&i.SelfServeCreateOrganizations,
 		&i.SelfServeCreateUsers,
+		&i.LogoUrl,
+		&i.DarkModeLogoUrl,
 	)
 	return i, err
 }
@@ -2128,7 +2130,7 @@ func (q *Queries) GetProjectTrustedDomains(ctx context.Context, projectID uuid.U
 
 const getProjectUISettings = `-- name: GetProjectUISettings :one
 SELECT
-    id, project_id, primary_color, detect_dark_mode_enabled, dark_mode_primary_color, create_time, update_time, log_in_layout, auto_create_organizations, self_serve_create_organizations, self_serve_create_users
+    id, project_id, primary_color, detect_dark_mode_enabled, dark_mode_primary_color, create_time, update_time, log_in_layout, auto_create_organizations, self_serve_create_organizations, self_serve_create_users, logo_url, dark_mode_logo_url
 FROM
     project_ui_settings
 WHERE
@@ -2150,6 +2152,8 @@ func (q *Queries) GetProjectUISettings(ctx context.Context, projectID uuid.UUID)
 		&i.AutoCreateOrganizations,
 		&i.SelfServeCreateOrganizations,
 		&i.SelfServeCreateUsers,
+		&i.LogoUrl,
+		&i.DarkModeLogoUrl,
 	)
 	return i, err
 }
@@ -4081,7 +4085,7 @@ WHERE
     id = $1
     AND project_id = $2
 RETURNING
-    id, project_id, primary_color, detect_dark_mode_enabled, dark_mode_primary_color, create_time, update_time, log_in_layout, auto_create_organizations, self_serve_create_organizations, self_serve_create_users
+    id, project_id, primary_color, detect_dark_mode_enabled, dark_mode_primary_color, create_time, update_time, log_in_layout, auto_create_organizations, self_serve_create_organizations, self_serve_create_users, logo_url, dark_mode_logo_url
 `
 
 type UpdateProjectUISettingsParams struct {
@@ -4121,6 +4125,8 @@ func (q *Queries) UpdateProjectUISettings(ctx context.Context, arg UpdateProject
 		&i.AutoCreateOrganizations,
 		&i.SelfServeCreateOrganizations,
 		&i.SelfServeCreateUsers,
+		&i.LogoUrl,
+		&i.DarkModeLogoUrl,
 	)
 	return i, err
 }

--- a/internal/common/store/queries/models.go
+++ b/internal/common/store/queries/models.go
@@ -438,6 +438,8 @@ type ProjectUiSetting struct {
 	AutoCreateOrganizations      bool
 	SelfServeCreateOrganizations bool
 	SelfServeCreateUsers         bool
+	LogoUrl                      *string
+	DarkModeLogoUrl              *string
 }
 
 type ProjectWebhookSetting struct {

--- a/internal/configapi/store/queries/models.go
+++ b/internal/configapi/store/queries/models.go
@@ -438,6 +438,8 @@ type ProjectUiSetting struct {
 	AutoCreateOrganizations      bool
 	SelfServeCreateOrganizations bool
 	SelfServeCreateUsers         bool
+	LogoUrl                      *string
+	DarkModeLogoUrl              *string
 }
 
 type ProjectWebhookSetting struct {

--- a/internal/defaultoauth/store/queries/models.go
+++ b/internal/defaultoauth/store/queries/models.go
@@ -438,6 +438,8 @@ type ProjectUiSetting struct {
 	AutoCreateOrganizations      bool
 	SelfServeCreateOrganizations bool
 	SelfServeCreateUsers         bool
+	LogoUrl                      *string
+	DarkModeLogoUrl              *string
 }
 
 type ProjectWebhookSetting struct {

--- a/internal/frontend/store/queries/models.go
+++ b/internal/frontend/store/queries/models.go
@@ -438,6 +438,8 @@ type ProjectUiSetting struct {
 	AutoCreateOrganizations      bool
 	SelfServeCreateOrganizations bool
 	SelfServeCreateUsers         bool
+	LogoUrl                      *string
+	DarkModeLogoUrl              *string
 }
 
 type ProjectWebhookSetting struct {

--- a/internal/frontend/store/queries/queries-frontend.sql.go
+++ b/internal/frontend/store/queries/queries-frontend.sql.go
@@ -1092,7 +1092,7 @@ func (q *Queries) GetProjectTrustedDomains(ctx context.Context, projectID uuid.U
 
 const getProjectUISettings = `-- name: GetProjectUISettings :one
 SELECT
-    id, project_id, primary_color, detect_dark_mode_enabled, dark_mode_primary_color, create_time, update_time, log_in_layout, auto_create_organizations, self_serve_create_organizations, self_serve_create_users
+    id, project_id, primary_color, detect_dark_mode_enabled, dark_mode_primary_color, create_time, update_time, log_in_layout, auto_create_organizations, self_serve_create_organizations, self_serve_create_users, logo_url, dark_mode_logo_url
 FROM
     project_ui_settings
 WHERE
@@ -1114,6 +1114,8 @@ func (q *Queries) GetProjectUISettings(ctx context.Context, projectID uuid.UUID)
 		&i.AutoCreateOrganizations,
 		&i.SelfServeCreateOrganizations,
 		&i.SelfServeCreateUsers,
+		&i.LogoUrl,
+		&i.DarkModeLogoUrl,
 	)
 	return i, err
 }

--- a/internal/intermediate/store/queries/models.go
+++ b/internal/intermediate/store/queries/models.go
@@ -438,6 +438,8 @@ type ProjectUiSetting struct {
 	AutoCreateOrganizations      bool
 	SelfServeCreateOrganizations bool
 	SelfServeCreateUsers         bool
+	LogoUrl                      *string
+	DarkModeLogoUrl              *string
 }
 
 type ProjectWebhookSetting struct {

--- a/internal/intermediate/store/queries/queries-intermediate.sql.go
+++ b/internal/intermediate/store/queries/queries-intermediate.sql.go
@@ -433,7 +433,7 @@ const createProjectUISettings = `-- name: CreateProjectUISettings :one
 INSERT INTO project_ui_settings (id, project_id)
     VALUES (gen_random_uuid (), $1)
 RETURNING
-    id, project_id, primary_color, detect_dark_mode_enabled, dark_mode_primary_color, create_time, update_time, log_in_layout, auto_create_organizations, self_serve_create_organizations, self_serve_create_users
+    id, project_id, primary_color, detect_dark_mode_enabled, dark_mode_primary_color, create_time, update_time, log_in_layout, auto_create_organizations, self_serve_create_organizations, self_serve_create_users, logo_url, dark_mode_logo_url
 `
 
 func (q *Queries) CreateProjectUISettings(ctx context.Context, projectID uuid.UUID) (ProjectUiSetting, error) {
@@ -451,6 +451,8 @@ func (q *Queries) CreateProjectUISettings(ctx context.Context, projectID uuid.UU
 		&i.AutoCreateOrganizations,
 		&i.SelfServeCreateOrganizations,
 		&i.SelfServeCreateUsers,
+		&i.LogoUrl,
+		&i.DarkModeLogoUrl,
 	)
 	return i, err
 }
@@ -1404,7 +1406,7 @@ func (q *Queries) GetProjectTrustedDomains(ctx context.Context, projectID uuid.U
 
 const getProjectUISettings = `-- name: GetProjectUISettings :one
 SELECT
-    id, project_id, primary_color, detect_dark_mode_enabled, dark_mode_primary_color, create_time, update_time, log_in_layout, auto_create_organizations, self_serve_create_organizations, self_serve_create_users
+    id, project_id, primary_color, detect_dark_mode_enabled, dark_mode_primary_color, create_time, update_time, log_in_layout, auto_create_organizations, self_serve_create_organizations, self_serve_create_users, logo_url, dark_mode_logo_url
 FROM
     project_ui_settings
 WHERE
@@ -1426,6 +1428,8 @@ func (q *Queries) GetProjectUISettings(ctx context.Context, projectID uuid.UUID)
 		&i.AutoCreateOrganizations,
 		&i.SelfServeCreateOrganizations,
 		&i.SelfServeCreateUsers,
+		&i.LogoUrl,
+		&i.DarkModeLogoUrl,
 	)
 	return i, err
 }

--- a/internal/intermediate/store/settings.go
+++ b/internal/intermediate/store/settings.go
@@ -38,29 +38,39 @@ func (s *Store) GetSettings(ctx context.Context, req *intermediatev1.GetSettings
 		return nil, fmt.Errorf("get project ui settings: %w", err)
 	}
 
-	logoKey := fmt.Sprintf("vault-ui-settings-v1/%s/logo", idformat.Project.Format(projectID))
-	logoExists, err := s.getUserContentFileExists(ctx, logoKey)
-	if err != nil {
-		return nil, fmt.Errorf("failed to check if logo file exists: %w", err)
-	}
-	logoURL := ""
-	if logoExists {
-		logoURL, err = s.buildPresignedGetUrlForFile(ctx, logoKey)
+	var logoURL string
+	if qProjectUISettings.LogoUrl != nil {
+		logoURL = *qProjectUISettings.LogoUrl
+	} else {
+		logoKey := fmt.Sprintf("vault-ui-settings-v1/%s/logo", idformat.Project.Format(projectID))
+		logoExists, err := s.getUserContentFileExists(ctx, logoKey)
 		if err != nil {
-			return nil, fmt.Errorf("failed to build presigned URL for logo file: %w", err)
+			return nil, fmt.Errorf("failed to check if logo file exists: %w", err)
+		}
+
+		if logoExists {
+			logoURL, err = s.buildPresignedGetUrlForFile(ctx, logoKey)
+			if err != nil {
+				return nil, fmt.Errorf("failed to build presigned URL for logo file: %w", err)
+			}
 		}
 	}
 
-	darkModeLogoKey := fmt.Sprintf("vault-ui-settings-v1/%s/logo-dark", idformat.Project.Format(projectID))
-	darkModeLogoExists, err := s.getUserContentFileExists(ctx, darkModeLogoKey)
-	if err != nil {
-		return nil, fmt.Errorf("failed to check if dark mode logo file exists: %w", err)
-	}
-	darkModeLogoURL := ""
-	if darkModeLogoExists {
-		darkModeLogoURL, err = s.buildPresignedGetUrlForFile(ctx, darkModeLogoKey)
+	var darkModeLogoURL string
+	if qProjectUISettings.DarkModeLogoUrl != nil {
+		darkModeLogoURL = *qProjectUISettings.DarkModeLogoUrl
+	} else {
+		darkModeLogoKey := fmt.Sprintf("vault-ui-settings-v1/%s/logo-dark", idformat.Project.Format(projectID))
+		darkModeLogoExists, err := s.getUserContentFileExists(ctx, darkModeLogoKey)
 		if err != nil {
-			return nil, fmt.Errorf("failed to build presigned URL for dark mode logo file: %w", err)
+			return nil, fmt.Errorf("failed to check if dark mode logo file exists: %w", err)
+		}
+
+		if darkModeLogoExists {
+			darkModeLogoURL, err = s.buildPresignedGetUrlForFile(ctx, darkModeLogoKey)
+			if err != nil {
+				return nil, fmt.Errorf("failed to build presigned URL for dark mode logo file: %w", err)
+			}
 		}
 	}
 

--- a/internal/oidc/store/queries/models.go
+++ b/internal/oidc/store/queries/models.go
@@ -438,6 +438,8 @@ type ProjectUiSetting struct {
 	AutoCreateOrganizations      bool
 	SelfServeCreateOrganizations bool
 	SelfServeCreateUsers         bool
+	LogoUrl                      *string
+	DarkModeLogoUrl              *string
 }
 
 type ProjectWebhookSetting struct {

--- a/internal/saml/store/queries/models.go
+++ b/internal/saml/store/queries/models.go
@@ -438,6 +438,8 @@ type ProjectUiSetting struct {
 	AutoCreateOrganizations      bool
 	SelfServeCreateOrganizations bool
 	SelfServeCreateUsers         bool
+	LogoUrl                      *string
+	DarkModeLogoUrl              *string
 }
 
 type ProjectWebhookSetting struct {

--- a/internal/scim/store/queries/models.go
+++ b/internal/scim/store/queries/models.go
@@ -438,6 +438,8 @@ type ProjectUiSetting struct {
 	AutoCreateOrganizations      bool
 	SelfServeCreateOrganizations bool
 	SelfServeCreateUsers         bool
+	LogoUrl                      *string
+	DarkModeLogoUrl              *string
 }
 
 type ProjectWebhookSetting struct {

--- a/internal/store/projects.go
+++ b/internal/store/projects.go
@@ -1,0 +1,62 @@
+package store
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/tesseral-labs/tesseral/internal/store/idformat"
+	"github.com/tesseral-labs/tesseral/internal/store/queries"
+)
+
+type UpdateProjectRequest struct {
+	ProjectID       string
+	VaultDomain     string
+	LogoURL         string
+	DarkModeLogoURL string
+}
+
+func (s *Store) UpdateProject(ctx context.Context, req *UpdateProjectRequest) error {
+	_, q, commit, rollback, err := s.tx(ctx)
+	if err != nil {
+		return err
+	}
+	defer rollback()
+
+	projectID, err := idformat.Project.Parse(req.ProjectID)
+	if err != nil {
+		return fmt.Errorf("parse project id: %w", err)
+	}
+
+	if req.VaultDomain != "" {
+		if _, err := q.UpdateProject(ctx, queries.UpdateProjectParams{
+			ID:          projectID,
+			VaultDomain: req.VaultDomain,
+		}); err != nil {
+			return fmt.Errorf("update project: %w", err)
+		}
+	}
+
+	if req.LogoURL != "" {
+		if _, err := q.UpdateProjectLogoURL(ctx, queries.UpdateProjectLogoURLParams{
+			ProjectID: projectID,
+			LogoUrl:   &req.LogoURL,
+		}); err != nil {
+			return fmt.Errorf("update project logo url: %w", err)
+		}
+	}
+
+	if req.DarkModeLogoURL != "" {
+		if _, err := q.UpdateProjectDarkModeLogoURL(ctx, queries.UpdateProjectDarkModeLogoURLParams{
+			ProjectID:       projectID,
+			DarkModeLogoUrl: &req.DarkModeLogoURL,
+		}); err != nil {
+			return fmt.Errorf("update project dark mode logo url: %w", err)
+		}
+	}
+
+	if err := commit(); err != nil {
+		return fmt.Errorf("commit: %w", err)
+	}
+
+	return nil
+}

--- a/internal/store/queries/models.go
+++ b/internal/store/queries/models.go
@@ -438,6 +438,8 @@ type ProjectUiSetting struct {
 	AutoCreateOrganizations      bool
 	SelfServeCreateOrganizations bool
 	SelfServeCreateUsers         bool
+	LogoUrl                      *string
+	DarkModeLogoUrl              *string
 }
 
 type ProjectWebhookSetting struct {

--- a/internal/store/queries/queries.sql.go
+++ b/internal/store/queries/queries.sql.go
@@ -177,7 +177,7 @@ const createProjectUISettings = `-- name: CreateProjectUISettings :one
 INSERT INTO project_ui_settings (id, project_id, primary_color, detect_dark_mode_enabled)
     VALUES ($1, $2, $3, $4)
 RETURNING
-    id, project_id, primary_color, detect_dark_mode_enabled, dark_mode_primary_color, create_time, update_time, log_in_layout, auto_create_organizations, self_serve_create_organizations, self_serve_create_users
+    id, project_id, primary_color, detect_dark_mode_enabled, dark_mode_primary_color, create_time, update_time, log_in_layout, auto_create_organizations, self_serve_create_organizations, self_serve_create_users, logo_url, dark_mode_logo_url
 `
 
 type CreateProjectUISettingsParams struct {
@@ -207,6 +207,8 @@ func (q *Queries) CreateProjectUISettings(ctx context.Context, arg CreateProject
 		&i.AutoCreateOrganizations,
 		&i.SelfServeCreateOrganizations,
 		&i.SelfServeCreateUsers,
+		&i.LogoUrl,
+		&i.DarkModeLogoUrl,
 	)
 	return i, err
 }
@@ -494,6 +496,138 @@ func (q *Queries) GetUserByID(ctx context.Context, id uuid.UUID) (User, error) {
 		&i.DisplayName,
 		&i.ProfilePictureUrl,
 		&i.GithubUserID,
+	)
+	return i, err
+}
+
+const updateProject = `-- name: UpdateProject :one
+UPDATE
+    projects
+SET
+    vault_domain = $2
+WHERE
+    id = $1
+RETURNING
+    id, organization_id, log_in_with_password, log_in_with_google, log_in_with_microsoft, google_oauth_client_id, microsoft_oauth_client_id, google_oauth_client_secret_ciphertext, microsoft_oauth_client_secret_ciphertext, display_name, create_time, update_time, logins_disabled, log_in_with_authenticator_app, log_in_with_passkey, log_in_with_email, log_in_with_saml, redirect_uri, after_login_redirect_uri, after_signup_redirect_uri, vault_domain, email_send_from_domain, cookie_domain, email_quota_daily, stripe_customer_id, entitled_custom_vault_domains, entitled_backend_api_keys, log_in_with_github, github_oauth_client_id, github_oauth_client_secret_ciphertext, api_keys_enabled, api_key_secret_token_prefix, audit_logs_enabled, log_in_with_oidc
+`
+
+type UpdateProjectParams struct {
+	ID          uuid.UUID
+	VaultDomain string
+}
+
+func (q *Queries) UpdateProject(ctx context.Context, arg UpdateProjectParams) (Project, error) {
+	row := q.db.QueryRow(ctx, updateProject, arg.ID, arg.VaultDomain)
+	var i Project
+	err := row.Scan(
+		&i.ID,
+		&i.OrganizationID,
+		&i.LogInWithPassword,
+		&i.LogInWithGoogle,
+		&i.LogInWithMicrosoft,
+		&i.GoogleOauthClientID,
+		&i.MicrosoftOauthClientID,
+		&i.GoogleOauthClientSecretCiphertext,
+		&i.MicrosoftOauthClientSecretCiphertext,
+		&i.DisplayName,
+		&i.CreateTime,
+		&i.UpdateTime,
+		&i.LoginsDisabled,
+		&i.LogInWithAuthenticatorApp,
+		&i.LogInWithPasskey,
+		&i.LogInWithEmail,
+		&i.LogInWithSaml,
+		&i.RedirectUri,
+		&i.AfterLoginRedirectUri,
+		&i.AfterSignupRedirectUri,
+		&i.VaultDomain,
+		&i.EmailSendFromDomain,
+		&i.CookieDomain,
+		&i.EmailQuotaDaily,
+		&i.StripeCustomerID,
+		&i.EntitledCustomVaultDomains,
+		&i.EntitledBackendApiKeys,
+		&i.LogInWithGithub,
+		&i.GithubOauthClientID,
+		&i.GithubOauthClientSecretCiphertext,
+		&i.ApiKeysEnabled,
+		&i.ApiKeySecretTokenPrefix,
+		&i.AuditLogsEnabled,
+		&i.LogInWithOidc,
+	)
+	return i, err
+}
+
+const updateProjectDarkModeLogoURL = `-- name: UpdateProjectDarkModeLogoURL :one
+UPDATE
+    project_ui_settings
+SET
+    dark_mode_logo_url = $2
+WHERE
+    project_id = $1
+RETURNING
+    id, project_id, primary_color, detect_dark_mode_enabled, dark_mode_primary_color, create_time, update_time, log_in_layout, auto_create_organizations, self_serve_create_organizations, self_serve_create_users, logo_url, dark_mode_logo_url
+`
+
+type UpdateProjectDarkModeLogoURLParams struct {
+	ProjectID       uuid.UUID
+	DarkModeLogoUrl *string
+}
+
+func (q *Queries) UpdateProjectDarkModeLogoURL(ctx context.Context, arg UpdateProjectDarkModeLogoURLParams) (ProjectUiSetting, error) {
+	row := q.db.QueryRow(ctx, updateProjectDarkModeLogoURL, arg.ProjectID, arg.DarkModeLogoUrl)
+	var i ProjectUiSetting
+	err := row.Scan(
+		&i.ID,
+		&i.ProjectID,
+		&i.PrimaryColor,
+		&i.DetectDarkModeEnabled,
+		&i.DarkModePrimaryColor,
+		&i.CreateTime,
+		&i.UpdateTime,
+		&i.LogInLayout,
+		&i.AutoCreateOrganizations,
+		&i.SelfServeCreateOrganizations,
+		&i.SelfServeCreateUsers,
+		&i.LogoUrl,
+		&i.DarkModeLogoUrl,
+	)
+	return i, err
+}
+
+const updateProjectLogoURL = `-- name: UpdateProjectLogoURL :one
+UPDATE
+    project_ui_settings
+SET
+    logo_url = $2
+WHERE
+    project_id = $1
+RETURNING
+    id, project_id, primary_color, detect_dark_mode_enabled, dark_mode_primary_color, create_time, update_time, log_in_layout, auto_create_organizations, self_serve_create_organizations, self_serve_create_users, logo_url, dark_mode_logo_url
+`
+
+type UpdateProjectLogoURLParams struct {
+	ProjectID uuid.UUID
+	LogoUrl   *string
+}
+
+func (q *Queries) UpdateProjectLogoURL(ctx context.Context, arg UpdateProjectLogoURLParams) (ProjectUiSetting, error) {
+	row := q.db.QueryRow(ctx, updateProjectLogoURL, arg.ProjectID, arg.LogoUrl)
+	var i ProjectUiSetting
+	err := row.Scan(
+		&i.ID,
+		&i.ProjectID,
+		&i.PrimaryColor,
+		&i.DetectDarkModeEnabled,
+		&i.DarkModePrimaryColor,
+		&i.CreateTime,
+		&i.UpdateTime,
+		&i.LogInLayout,
+		&i.AutoCreateOrganizations,
+		&i.SelfServeCreateOrganizations,
+		&i.SelfServeCreateUsers,
+		&i.LogoUrl,
+		&i.DarkModeLogoUrl,
 	)
 	return i, err
 }

--- a/sqlc/queries.sql
+++ b/sqlc/queries.sql
@@ -141,3 +141,33 @@ SELECT
 FROM
     projects;
 
+-- name: UpdateProject :one
+UPDATE
+    projects
+SET
+    vault_domain = $2
+WHERE
+    id = $1
+RETURNING
+    *;
+
+-- name: UpdateProjectLogoURL :one
+UPDATE
+    project_ui_settings
+SET
+    logo_url = $2
+WHERE
+    project_id = $1
+RETURNING
+    *;
+
+-- name: UpdateProjectDarkModeLogoURL :one
+UPDATE
+    project_ui_settings
+SET
+    dark_mode_logo_url = $2
+WHERE
+    project_id = $1
+RETURNING
+    *;
+


### PR DESCRIPTION
This PR adds an `update-project` command to the ctl tool, which allows self-hosters to directly control, through the database, a Project's Vault domain and logos. This allows self-hosters to conveniently bypass dependencies on S3 and Cloudflare.

For logos, a new set of columns for `logo_url` and `dark_mode_logo_url` take precedence over other settings. If enabled, these are unconditionally used as the hotlinkable URL to use for presentational purposes.