### PR TITLE
[OPEN-606] Move Login flow query param state into localStorage

### DIFF
--- a/vault-ui/src/hooks/use-login-page-query-params.tsx
+++ b/vault-ui/src/hooks/use-login-page-query-params.tsx
@@ -7,30 +7,57 @@ interface LoginPageQueryParams {
   returnRelayedSessionTokenAsQueryParam: boolean;
 }
 
-export function useLoginPageQueryParams(): [LoginPageQueryParams, string] {
+export function useLoginPageQueryParams(): LoginPageQueryParams {
   const [searchParams, setSearchParams] = useSearchParams();
 
-  const [relayedSessionState] = useState(() => {
-    return searchParams.get("relayed-session-state");
+  const [relayedSessionState, setRelayedSessionState] = useState(() => {
+    return localStorage.getItem("relayed-session-state");
   });
 
-  const [redirectURI] = useState(() => {
-    return searchParams.get("redirect-uri");
+  const [redirectURI, setRedirectURI] = useState(() => {
+    return localStorage.getItem("redirect-uri");
   });
 
-  const [returnRelayedSessionTokenAsQueryParam] = useState(() => {
-    return searchParams.get("return-relayed-session-token-as-query-param");
+  const [
+    returnRelayedSessionTokenAsQueryParam,
+    setReturnRelayedSessionTokenAsQueryParam,
+  ] = useState(() => {
+    return localStorage.getItem("return-relayed-session-token-as-query-param");
   });
 
   useEffect(() => {
     const newParams = new URLSearchParams();
+
+    if (searchParams.has("relayed-session-state")) {
+      setRelayedSessionState(searchParams.get("relayed-session-state"));
+      localStorage.setItem(
+        "relayed-session-state",
+        searchParams.get("relayed-session-state")!,
+      );
+    }
+
+    if (searchParams.has("redirect-uri")) {
+      setRedirectURI(searchParams.get("redirect-uri"));
+      localStorage.setItem("redirect-uri", searchParams.get("redirect-uri")!);
+    }
+
+    if (searchParams.has("return-relayed-session-token-as-query-param")) {
+      setReturnRelayedSessionTokenAsQueryParam(
+        searchParams.get("return-relayed-session-token-as-query-param"),
+      );
+      localStorage.setItem(
+        "return-relayed-session-token-as-query-param",
+        searchParams.get("return-relayed-session-token-as-query-param")!,
+      );
+    }
+
     newParams.delete("relayed-session-state");
     newParams.delete("redirect-uri");
     newParams.delete("return-relayed-session-token-as-query-param");
     setSearchParams(newParams);
-  }, [setSearchParams]);
+  }, [searchParams, setSearchParams]);
 
-  const state = useMemo(() => {
+  return useMemo(() => {
     return {
       relayedSessionState: relayedSessionState || "",
       redirectURI: redirectURI || "",
@@ -38,27 +65,4 @@ export function useLoginPageQueryParams(): [LoginPageQueryParams, string] {
         returnRelayedSessionTokenAsQueryParam === "1",
     } as LoginPageQueryParams;
   }, [relayedSessionState, redirectURI, returnRelayedSessionTokenAsQueryParam]);
-
-  const serialized = useMemo(() => {
-    const search = new URLSearchParams();
-    if (relayedSessionState) {
-      search.set("relayed-session-state", relayedSessionState);
-    }
-    if (redirectURI) {
-      search.set("redirect-uri", redirectURI);
-    }
-    if (returnRelayedSessionTokenAsQueryParam) {
-      search.set(
-        "return-relayed-session-token-as-query-param",
-        returnRelayedSessionTokenAsQueryParam,
-      );
-    }
-
-    if (search.size === 0) {
-      return "";
-    }
-    return `?${search.toString()}`;
-  }, [redirectURI, relayedSessionState, returnRelayedSessionTokenAsQueryParam]);
-
-  return [state, serialized];
 }

--- a/vault-ui/src/pages/login/FinishLoginPage.tsx
+++ b/vault-ui/src/pages/login/FinishLoginPage.tsx
@@ -40,6 +40,11 @@ export function FinishLoginPage() {
         }
       }
 
+      // clear out any localstorage state related to useLoginPageQueryParams
+      localStorage.removeItem("relayed-session-state");
+      localStorage.removeItem("redirect-uri");
+      localStorage.removeItem("return-relayed-session-token-as-query-param");
+
       window.location.href = url.toString();
     })();
   }, [settings, exchangeIntermediateSessionForSessionAsync]);

--- a/vault-ui/src/pages/login/LoginPage.tsx
+++ b/vault-ui/src/pages/login/LoginPage.tsx
@@ -107,10 +107,11 @@ function LoginPageContents() {
     createIntermediateSession,
   );
 
-  const [
-    { relayedSessionState, redirectURI, returnRelayedSessionTokenAsQueryParam },
-    serializedQueryParamState,
-  ] = useLoginPageQueryParams();
+  const {
+    relayedSessionState,
+    redirectURI,
+    returnRelayedSessionTokenAsQueryParam,
+  } = useLoginPageQueryParams();
 
   async function createIntermediateSessionWithRelayedSessionState() {
     await createIntermediateSessionMutation.mutateAsync({
@@ -448,7 +449,7 @@ function LoginPageContents() {
         <p className="text-center mt-4 text-xs text-muted-foreground">
           Don't have an account?{" "}
           <Link
-            to={`/signup${serializedQueryParamState}`}
+            to="/signup"
             className="cursor-pointer text-foreground underline underline-offset-2 decoration-muted-foreground"
           >
             Sign up.

--- a/vault-ui/src/pages/login/SignupPage.tsx
+++ b/vault-ui/src/pages/login/SignupPage.tsx
@@ -102,10 +102,11 @@ function SignupPageContents() {
     createIntermediateSession,
   );
 
-  const [
-    { relayedSessionState, redirectURI, returnRelayedSessionTokenAsQueryParam },
-    serializedQueryParamState,
-  ] = useLoginPageQueryParams();
+  const {
+    relayedSessionState,
+    redirectURI,
+    returnRelayedSessionTokenAsQueryParam,
+  } = useLoginPageQueryParams();
 
   async function createIntermediateSessionWithRelayedSessionState() {
     await createIntermediateSessionMutation.mutateAsync({
@@ -335,7 +336,7 @@ function SignupPageContents() {
         <p className="mt-4 text-xs text-muted-foreground">
           Already have an account?{" "}
           <Link
-            to={`/login${serializedQueryParamState}`}
+            to="/login"
             className="cursor-pointer text-foreground underline underline-offset-2 decoration-muted-foreground"
           >
             Log in.


### PR DESCRIPTION
This PR moves the login flow's URL-supplied state (`relayed-session-state`, `redirect-uri`, and `return-relayed-session-token-as-query-param`) to persist in localstorage.

Today, this state is only loaded from the URL, but we also strip it from the URL upon loading it. That interacts poorly with browser history -- certain patterns of hitting back or refreshing can lose that state.

With this PR, this state continues to be accepted as a query parameter, but is persisted in local storage. Finishing a login resets the state.