### PR TITLE
Custom Emails: Fix verify_email payload field name

### DIFF
--- a/internal/backgroundworker/store/email.go
+++ b/internal/backgroundworker/store/email.go
@@ -34,9 +34,9 @@ func (s *Store) SendEmailVerifyEmail(ctx context.Context, req *SendEmailVerifyEm
 			ProjectID: req.ProjectID,
 			EventType: "custom_email.verify_email",
 			Payload: map[string]any{
-				"type":                  "custom_email.verify_email",
-				"emailAddress":          req.EmailAddress,
-				"emailVerificationCode": req.EmailVerificationCode,
+				"type":                           "custom_email.verify_email",
+				"emailAddress":                   req.EmailAddress,
+				"emailVerificationChallengeCode": req.EmailVerificationCode,
 			},
 		}); err != nil {
 			return fmt.Errorf("send webhook: %w", err)


### PR DESCRIPTION
For consistency, this PR updates the `custom_email.verify_email` webhook payload to use the field `emailVerificationChallengeCode` (currently: `emailVerificationCode`). This is the more correct public-facing name for these codes.

```json
{
  "emailAddress": "ulysse.carion@ssoready.com",
  "emailVerificationChallengeCode": "email_verification_challenge_code_505d7k87168m6jg28vc6j20ix",
  "type": "custom_email.verify_email"
}
```