### PR TITLE
[OPEN-609] [OPEN-607] Vault: Recall last email, make SAML/OIDC "primary" in UI when available

### DIFF
--- a/vault-ui/src/pages/login/SignupPage.tsx
+++ b/vault-ui/src/pages/login/SignupPage.tsx
@@ -198,6 +198,16 @@ function SignupPageContents() {
     return () => clearInterval(interval);
   }, [watchEmail]);
 
+  async function handleLogInWithSaml(samlConnectionId: string) {
+    await createIntermediateSessionWithRelayedSessionState();
+    window.location.href = `/api/saml/v1/${samlConnectionId}/init`;
+  }
+
+  async function handleLogInWithOidc(oidcConnectionId: string) {
+    await createIntermediateSessionWithRelayedSessionState();
+    window.location.href = `/api/oidc/v1/${oidcConnectionId}/init`;
+  }
+
   const { data: listSAMLOrganizationsResponse } = useQuery(
     listSAMLOrganizations,
     {
@@ -227,6 +237,10 @@ function SignupPageContents() {
     settings.logInWithPassword ||
     settings.logInWithSaml ||
     settings.logInWithOidc;
+
+  const hasSAMLOrOIDCConnection =
+    (listSAMLOrganizationsResponse?.organizations?.length ?? 0) > 0 ||
+    (listOIDCOrganizationsResponse?.organizations?.length ?? 0) > 0;
 
   return (
     <LoginFlowCard>
@@ -282,7 +296,7 @@ function SignupPageContents() {
 
         {hasBelowFoldMethod && (
           <Form {...form}>
-            <form onSubmit={form.handleSubmit(handleSubmit)}>
+            <form>
               <FormField
                 control={form.control}
                 name="email"
@@ -297,38 +311,54 @@ function SignupPageContents() {
                 )}
               />
 
+              {listSAMLOrganizationsResponse?.organizations?.map((org) => (
+                <Button
+                  key={org.id}
+                  type="submit"
+                  className="mt-4 w-full"
+                  onClick={() =>
+                    handleLogInWithSaml(org.primarySamlConnectionId)
+                  }
+                  disabled={submitting}
+                >
+                  {submitting && (
+                    <LoaderCircleIcon className="h-4 w-4 animate-spin" />
+                  )}
+                  Log in with SAML ({org.displayName})
+                </Button>
+              ))}
+
+              {listOIDCOrganizationsResponse?.organizations?.map((org) => (
+                <Button
+                  key={org.id}
+                  type="submit"
+                  className="mt-4 w-full"
+                  onClick={() =>
+                    handleLogInWithOidc(org.primaryOidcConnectionId)
+                  }
+                  disabled={submitting}
+                >
+                  {submitting && (
+                    <LoaderCircleIcon className="h-4 w-4 animate-spin" />
+                  )}
+                  Log in with OIDC ({org.displayName})
+                </Button>
+              ))}
+
               <Button
-                type="submit"
+                type={hasSAMLOrOIDCConnection ? "button" : "submit"}
+                variant={
+                  hasSAMLOrOIDCConnection ? "secondary" : undefined
+                }
                 className="mt-4 w-full"
                 disabled={submitting}
+                onClick={form.handleSubmit(handleSubmit)}
               >
                 {submitting && (
                   <LoaderCircleIcon className="h-4 w-4 animate-spin" />
                 )}
                 Sign up
               </Button>
-
-              {listSAMLOrganizationsResponse?.organizations?.map((org) => (
-                <a
-                  key={org.id}
-                  href={`/api/saml/v1/${org.primarySamlConnectionId}/init`}
-                >
-                  <Button type="button" className="mt-4 w-full">
-                    Log in with SAML ({org.displayName})
-                  </Button>
-                </a>
-              ))}
-
-              {listOIDCOrganizationsResponse?.organizations?.map((org) => (
-                <a
-                  key={org.id}
-                  href={`/api/oidc/v1/${org.primaryOidcConnectionId}/init`}
-                >
-                  <Button type="button" className="mt-4 w-full">
-                    Log in with OIDC ({org.displayName})
-                  </Button>
-                </a>
-              ))}
             </form>
           </Form>
         )}

--- a/vault-ui/src/pages/login/SignupPage.tsx
+++ b/vault-ui/src/pages/login/SignupPage.tsx
@@ -347,9 +347,7 @@ function SignupPageContents() {
 
               <Button
                 type={hasSAMLOrOIDCConnection ? "button" : "submit"}
-                variant={
-                  hasSAMLOrOIDCConnection ? "secondary" : undefined
-                }
+                variant={hasSAMLOrOIDCConnection ? "secondary" : undefined}
                 className="mt-4 w-full"
                 disabled={submitting}
                 onClick={form.handleSubmit(handleSubmit)}


### PR DESCRIPTION
This PR makes improvements to the end user experience of logging in when SAML or OIDC are available:

1. The login page recalls the last used email, and uses that as a default for subsequent visits.
2. When SAML or OIDC connections are available, the login and signup page display that as the "primary" option. They have `type="submit"` and appear above email/password logins, which are now secondary options.

<img width="405" height="309" alt="Screenshot 2025-08-13 at 10 55 03 AM" src="https://github.com/user-attachments/assets/41844831-d636-48ab-8cb7-428572f73508" />

<img width="411" height="364" alt="Screenshot 2025-08-13 at 10 55 58 AM" src="https://github.com/user-attachments/assets/07853d04-ace9-4f21-af86-a86fb6382294" />
