### PR TITLE
[OPEN-605] Add tesseral-internal-api to docker image builds

### DIFF
--- a/.github/workflows/docker-images-stable.yml
+++ b/.github/workflows/docker-images-stable.yml
@@ -43,7 +43,7 @@ jobs:
         id: push
         uses: docker/build-push-action@v6
         with:
-          context: cmd/tesseral-internal-api
+          context: .
           file: cmd/tesseral-internal-api/Dockerfile
           platforms: linux/amd64,linux/arm64
           push: true

--- a/.github/workflows/docker-images-stable.yml
+++ b/.github/workflows/docker-images-stable.yml
@@ -16,6 +16,47 @@ env:
   IMAGE_TAGS: type=semver,pattern={{version}}
 
 jobs:
+  tesseral-internal-api:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/tesseral-labs/${{ env.IMAGE_PREFIX }}tesseral-internal-api
+          tags: ${{ env.IMAGE_TAGS }}
+
+      - name: Build and push Docker image
+        id: push
+        uses: docker/build-push-action@v6
+        with:
+          context: cmd/tesseral-internal-api
+          file: cmd/tesseral-internal-api/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ghcr.io/tesseral-labs/${{ env.IMAGE_PREFIX }}tesseral-internal-api
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true
+
   tesseral-backend-api:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/docker-images-unstable.yml
+++ b/.github/workflows/docker-images-unstable.yml
@@ -40,7 +40,7 @@ jobs:
         id: push
         uses: docker/build-push-action@v6
         with:
-          context: cmd/tesseral-internal-api
+          context: .
           file: cmd/tesseral-internal-api/Dockerfile
           platforms: linux/amd64,linux/arm64
           push: true

--- a/.github/workflows/docker-images-unstable.yml
+++ b/.github/workflows/docker-images-unstable.yml
@@ -13,6 +13,47 @@ env:
   IMAGE_TAGS: type=sha
 
 jobs:
+  tesseral-internal-api:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/tesseral-labs/${{ env.IMAGE_PREFIX }}tesseral-internal-api
+          tags: ${{ env.IMAGE_TAGS }}
+
+      - name: Build and push Docker image
+        id: push
+        uses: docker/build-push-action@v6
+        with:
+          context: cmd/tesseral-internal-api
+          file: cmd/tesseral-internal-api/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ghcr.io/tesseral-labs/${{ env.IMAGE_PREFIX }}tesseral-internal-api
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true
+
   tesseral-backend-api:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This PR adds tesseral-internal-api builds to the stable and unstable Docker channels.