### PR TITLE
Add dangerously_store_plaintext_private_keys kms backend

### DIFF
--- a/internal/kms/kms.go
+++ b/internal/kms/kms.go
@@ -29,6 +29,10 @@ type Config struct {
 
 func New(ctx context.Context, config Config) (*KMS, error) {
 	switch config.Backend {
+	case "dangerously_store_plaintext_private_keys":
+		return &KMS{
+			config: config,
+		}, nil
 	case "aws_kms_v1":
 		awsConfig, err := awsconfig.LoadDefaultConfig(ctx)
 		if err != nil {
@@ -62,6 +66,8 @@ func New(ctx context.Context, config Config) (*KMS, error) {
 
 func (k *KMS) Encrypt(ctx context.Context, plaintext []byte) ([]byte, error) {
 	switch k.config.Backend {
+	case "dangerously_store_plaintext_private_keys":
+		return plaintext, nil
 	case "aws_kms_v1":
 		encryptRes, err := k.awskmsClient.Encrypt(ctx, &awskms.EncryptInput{
 			KeyId:               &k.config.AWSKMSV1KeyID,
@@ -90,6 +96,8 @@ func (k *KMS) Encrypt(ctx context.Context, plaintext []byte) ([]byte, error) {
 
 func (k *KMS) Decrypt(ctx context.Context, ciphertext []byte) ([]byte, error) {
 	switch k.config.Backend {
+	case "dangerously_store_plaintext_private_keys":
+		return ciphertext, nil
 	case "aws_kms_v1":
 		decryptRes, err := k.awskmsClient.Decrypt(ctx, &awskms.DecryptInput{
 			KeyId:               &k.config.AWSKMSV1KeyID,

--- a/internal/kms/kms_test.go
+++ b/internal/kms/kms_test.go
@@ -13,6 +13,24 @@ var (
 	gcpKMSV1KeyName = os.Getenv("TESSERAL_INTERNAL_KMS_TEST_GCP_V1_KMS_KEY_NAME")
 )
 
+func TestDangerouslyStorePlaintextPrivateKeys(t *testing.T) {
+	k, err := New(t.Context(), Config{
+		Backend: "dangerously_store_plaintext_private_keys",
+	})
+	require.NoError(t, err)
+
+	var plaintext [256]byte
+	_, _ = rand.Read(plaintext[:]) // infallible
+
+	ciphertext, err := k.Encrypt(t.Context(), plaintext[:])
+	require.NoError(t, err)
+
+	plaintext2, err := k.Decrypt(t.Context(), ciphertext)
+	require.NoError(t, err)
+
+	require.Equal(t, plaintext[:], plaintext2)
+}
+
 func TestAWSKMS(t *testing.T) {
 	if awsKMSV1KeyID == "" {
 		t.Skip("AWS KMS key ID not set")


### PR DESCRIPTION
This PR adds a new KMS backend, alongside `aws_kms_v1` and `gcp_kms_v1`, called `dangerously_store_plaintext_private_keys`. The name is chosen to deter misuse.

This new backend exists in service of local development setups for self-hosting Tesseral. Without this backend, a local development backend needs to mock out a "real" KMS backend. Such mocking adds complexity and confusion for self-hosters, and has little to no real security improvements.